### PR TITLE
Fix products query

### DIFF
--- a/src/components/CategoryPage/index.tsx
+++ b/src/components/CategoryPage/index.tsx
@@ -122,7 +122,7 @@ class CategoryPage extends React.Component<
                 />
               </div>
               <ProductsList
-                products={data.category.products}
+                products={data.products}
                 loading={loading}
                 filters={this.state}
                 attributes={data.attributes.edges.map(edge => edge.node)}

--- a/src/components/CategoryPage/queries.ts
+++ b/src/components/CategoryPage/queries.ts
@@ -9,6 +9,31 @@ export const GET_CATEGORY_AND_ATTRIBUTES = gql`
     $priceLte: Float
     $priceGte: Float
   ) {
+    products(
+      attributes: $attributes
+      categories: [$id]
+      first: $pageSize
+      sortBy: $sortBy
+      priceLte: $priceLte
+      priceGte: $priceGte
+    ) {
+      totalCount
+      edges {
+        node {
+          id
+          name
+          thumbnailUrl
+          category {
+            id
+            name
+          }
+          price {
+            amount
+            currency
+          }
+        }
+      }
+    }
     category(id: $id) {
       id
       name
@@ -20,30 +45,6 @@ export const GET_CATEGORY_AND_ATTRIBUTES = gql`
           node {
             id
             name
-          }
-        }
-      }
-      products(
-        attributes: $attributes
-        first: $pageSize
-        sortBy: $sortBy
-        price_Lte: $priceLte
-        price_Gte: $priceGte
-      ) {
-        totalCount
-        edges {
-          node {
-            id
-            name
-            thumbnailUrl
-            category {
-              id
-              name
-            }
-            price {
-              amount
-              currency
-            }
           }
         }
       }


### PR DESCRIPTION
After recent changes in the API, products should be no longer queried as
```
category(id) {
  products {
    ..
  }
}
```
Instead, the recommended way is to use a dedicated `products` query which now support filtering by categories and collections e.g.:

```
products(categories: [id]) {
  ..
}
```
This PR updates the query for category page to support the new API.
