### PR TITLE
Properly detect webpack production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "NODE_ENV=develop webpack-dev-server --history-api-fallback --open --watch --port 3000 --mode development",
-    "build": "webpack -p --progress",
-    "watch": "webpack -d --watch --progress --colors",
+    "build": "webpack -p",
+    "watch": "webpack -d --watch",
     "storybook": "start-storybook -p 9001 -c src/storybook/ -s src/",
     "codegen": "apollo-codegen generate 'src/**/*.ts' --target typescript --output ./src/core/types/saleor.ts --schema schema.json"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,125 +9,126 @@ const webpack = require("webpack");
 
 const sourceDir = path.join(__dirname, "./src");
 const distDir = path.join(__dirname, "./dist");
-const devMode = process.env.NODE_ENV !== "production";
 
-module.exports = {
-  resolve: {
-    extensions: [".ts", ".tsx", ".js", ".jsx"]
-  },
-  entry: {
-    app: `${sourceDir}/index.tsx`
-  },
-  output: {
-    path: distDir,
-    filename: "js/[name].js",
-    publicPath: "/"
-  },
-  devtool: "source-map",
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: "ts-loader"
-      },
-      {
-        test: /\.(scss|css)$/,
-        use: [
-          devMode ? "style-loader" : MiniCssExtractPlugin.loader,
-          { loader: "css-loader" },
-          { loader: "sass-loader" }
-        ]
-      },
-      {
-        test: /\.woff2?$|\.ttf$|\.eot$/,
-        use: [
-          {
-            loader: "file-loader",
-            options: {
-              name: "[name].[ext]",
-              outputPath: "fonts/",
-              publicPath: "/fonts/"
-            }
-          }
-        ]
-      },
-      {
-        test: /\.(gif|jpg|png|svg)$/,
-        use: [
-          {
-            loader: "file-loader",
-            options: {
-              name: "[name].[ext]",
-              outputPath: "images/",
-              publicPath: "/images/"
-            }
-          },
-          {
-            loader: "image-webpack-loader",
-            options: {
-              mozjpeg: {
-                progressive: true,
-                quality: 85
-              },
-              pngquant: {
-                quality: "65-90",
-                speed: 4
-              },
-              gifsicle: {
-                enabled: false
+module.exports = (env, argv) => {
+  const devMode = argv.mode !== "production";
+  return {
+    resolve: {
+      extensions: [".ts", ".tsx", ".js", ".jsx"]
+    },
+    entry: {
+      app: `${sourceDir}/index.tsx`
+    },
+    output: {
+      path: distDir,
+      filename: "js/[name].js",
+      publicPath: "/"
+    },
+    devtool: "source-map",
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          loader: "ts-loader"
+        },
+        {
+          test: /\.(scss|css)$/,
+          use: [
+            devMode ? "style-loader" : MiniCssExtractPlugin.loader,
+            { loader: "css-loader" },
+            { loader: "sass-loader" }
+          ]
+        },
+        {
+          test: /\.(woff2?|ttf|eot)$/,
+          use: [
+            {
+              loader: "file-loader",
+              options: {
+                name: "[name].[ext]",
+                outputPath: "fonts/",
+                publicPath: "/fonts/"
               }
             }
-          }
-        ]
-      }
-    ]
-  },
-  plugins: [
-    new CleanWebpackPlugin([distDir]),
-    new HtmlWebpackPlugin({
-      filename: `${distDir}/index.html`,
-      template: `${sourceDir}/index.html`
-    }),
-    new MiniCssExtractPlugin({
-      filename: devMode ? "[name].css" : "[name].[hash].css",
-      chunkFilename: devMode ? "[id].css" : "[id].[hash].css"
-    }),
-    // PWA plugins
-    new WebappWebpackPlugin({
-      logo: `${sourceDir}/images/favicon.svg`,
-      prefix: "images/favicons/",
-      favicons: {
-        appName: "Saleor ecommerce",
-        appDescription: "Store front for the Saloer ecommerce platform",
-        display: "standalone",
-        developerURL: null, // prevent retrieving from the nearest package.json
-        background: "#ddd",
-        theme_color: "#333",
-        icons: {
-          coast: false,
-          yandex: false
-        }
-      }
-    }),
-    new SWPrecacheWebpackPlugin({
-      cacheId: "saleor-store-front",
-      filename: "service-worker.js",
-      navigateFallback: "/index.html",
-      staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
-      runtimeCaching: [
+          ]
+        },
         {
-          urlPattern: /\/media\//,
-          handler: "networkFirst"
+          test: /\.(gif|jpg|png|svg)$/,
+          use: [
+            {
+              loader: "file-loader",
+              options: {
+                name: "[name].[ext]",
+                outputPath: "images/",
+                publicPath: "/images/"
+              }
+            },
+            {
+              loader: "image-webpack-loader",
+              options: {
+                mozjpeg: {
+                  progressive: true,
+                  quality: 85
+                },
+                pngquant: {
+                  quality: "65-90",
+                  speed: 4
+                },
+                gifsicle: {
+                  enabled: false
+                }
+              }
+            }
+          ]
         }
       ]
-    }),
-    new webpack.EnvironmentPlugin([
-      "npm_package_version",
-      "NODE_ENV",
-      "APP_GRAPHQL_URL"
-    ])
-  ],
-  node: {
-    fs: "empty"
+    },
+    plugins: [
+      new CleanWebpackPlugin([distDir]),
+      new HtmlWebpackPlugin({
+        filename: `${distDir}/index.html`,
+        template: `${sourceDir}/index.html`
+      }),
+      new MiniCssExtractPlugin({
+        filename: devMode ? "[name].css" : "[name].[hash].css",
+        chunkFilename: devMode ? "[id].css" : "[id].[hash].css"
+      }),
+      // PWA plugins
+      new WebappWebpackPlugin({
+        logo: `${sourceDir}/images/favicon.svg`,
+        prefix: "images/favicons/",
+        favicons: {
+          appName: "Saleor ecommerce",
+          appDescription: "Store front for the Saloer ecommerce platform",
+          display: "standalone",
+          developerURL: null, // prevent retrieving from the nearest package.json
+          background: "#ddd",
+          theme_color: "#333",
+          icons: {
+            coast: false,
+            yandex: false
+          }
+        }
+      }),
+      new SWPrecacheWebpackPlugin({
+        cacheId: "saleor-store-front",
+        filename: "service-worker.js",
+        navigateFallback: "/index.html",
+        staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
+        runtimeCaching: [
+          {
+            urlPattern: /\/media\//,
+            handler: "networkFirst"
+          }
+        ]
+      }),
+      new webpack.EnvironmentPlugin([
+        "npm_package_version",
+        "APP_GRAPHQL_URL"
+      ])
+    ],
+    node: {
+      fs: "empty"
+    }
   }
-};
+}


### PR DESCRIPTION
The old version had four different build modes:

* the "dry" build (`webpack -p`, `NODE_ENV=production`) - real production mode
* the "semi dry" build (`webpack -p`, `NODE_ENV` unset) - large files, no watch
* the "semi sweet" build (`webpack -d`, `NODE_ENV=production`) - watch but super slow
* the "sweet" build (`webpack -d`, `NODE_ENV` unset) - real development mode

This drops the dependency on NODE_ENV and reduces the number of resulting build types to two.