### PR TITLE
Fix PWA on iPhone

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,7 +99,7 @@ module.exports = (env, argv) => {
         prefix: "images/favicons/",
         favicons: {
           appName: "Saleor",
-          appDescription: "Store front for the Saleor ecommerce platform",
+          appDescription: "Storefront for the Saleor e-commerce platform",
           display: "standalone",
           developerURL: null, // prevent retrieving from the nearest package.json
           background: "#ddd",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,16 +98,12 @@ module.exports = (env, argv) => {
         logo: `${sourceDir}/images/favicon.png`,
         prefix: "images/favicons/",
         favicons: {
-          appName: "Saleor ecommerce",
-          appDescription: "Store front for the Saloer ecommerce platform",
+          appName: "Saleor",
+          appDescription: "Store front for the Saleor ecommerce platform",
           display: "standalone",
           developerURL: null, // prevent retrieving from the nearest package.json
           background: "#ddd",
           theme_color: "#333",
-          icons: {
-            coast: false,
-            yandex: false
-          }
         }
       }),
       new SWPrecacheWebpackPlugin({


### PR DESCRIPTION
close #139 

Apparently iOS devices uses `appName` even if it's too long and `shortAppName` is provided.
So just changed `Saleor e-commerce` to `Saleor`.

Also, removed no-icon generation for Yandex and the other one. It seems like a default configuration leftover, and I see no reason why we should not generate it.

Lack of icon was not a problem anymore (double checked on pwa.getsaleor.com) not sure what was the cause. 

### Screenshots
![screenshot 2018-11-12 at 14 24 43](https://user-images.githubusercontent.com/21290461/48350190-b9ae1580-e686-11e8-8a2d-1c726f3b2814.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
 