### PR TITLE
Trigger deploy only when tag was pushed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,5 +41,5 @@ workflows:
           requires:
             - build
           filters:
-            branches:
-              only: master
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
This PR changes CircleCI config to only deploy to S3 when a tag was pushed.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
