### PR TITLE
Set max width of images in product description as 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Handle quantity API errors in the cart #199 by @piotrgrundas
 - Fix sticky footer, adjust cart overlay to the mocks, cart summary fixes, fix error if no shipping method found #205 by @piotrgrundas
 - Disable ability to continue to billing without shipement chosen #211 by @piotrgrundas
+- Set max width of images in product description as 100% #220 by @jxltom

--- a/src/components/ProductDescription/scss/index.scss
+++ b/src/components/ProductDescription/scss/index.scss
@@ -26,6 +26,10 @@
     p {
       font-size: $small-font-size;
     }
+
+    img {
+      max-width: 100%;
+    }
   }
 
   &__action {


### PR DESCRIPTION
This PR fixes the overflow image in product description.

### Screenshots

Before:
![screenshot from 2019-01-22 18-04-24](https://user-images.githubusercontent.com/1401630/51527912-818a3680-1e70-11e9-8d51-6c58eabb534a.png)
After:
![screenshot from 2019-01-22 18-03-23](https://user-images.githubusercontent.com/1401630/51527916-82bb6380-1e70-11e9-8c27-8ef44d55c993.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.