### PR TITLE
Added context display name for better readability in devtools

### DIFF
--- a/src/checkout/context.tsx
+++ b/src/checkout/context.tsx
@@ -45,3 +45,5 @@ export const defaultContext = {
 export const CheckoutContext = createContext<CheckoutContextInterface>(
   defaultContext
 );
+
+CheckoutContext.displayName = "CheckoutContext";

--- a/src/components/CartProvider/context.ts
+++ b/src/components/CartProvider/context.ts
@@ -39,3 +39,5 @@ export const CartContext = createContext<CartInterface>({
   subtract: (variantId, quantity = 1) => {}
 });
 /* tslint:enable:no-empty */
+
+CartContext.displayName = "CartContext";

--- a/src/components/Overlay/context.tsx
+++ b/src/components/Overlay/context.tsx
@@ -48,3 +48,5 @@ export const OverlayContext = React.createContext<OverlayContextInterface>({
   type: null
 });
 /* tslint:enable:no-empty */
+
+OverlayContext.displayName = "OverlayContext";

--- a/src/components/ShopProvider/context.ts
+++ b/src/components/ShopProvider/context.ts
@@ -16,3 +16,5 @@ export const defaultContext: getShop_shop = {
 };
 
 export const ShopContext = createContext<getShop_shop>(defaultContext);
+
+ShopContext.displayName = "ShopContext";

--- a/src/components/User/context.tsx
+++ b/src/components/User/context.tsx
@@ -25,3 +25,5 @@ export const UserContext = React.createContext<UserContextInterface>({
   user: null
 });
 /* tslint:enable:no-empty */
+
+UserContext.displayName = "UserContext";


### PR DESCRIPTION
Alternatively display names can be shorter by dropping the `Context` at the end since context nodes are always followed by  `.Provider` or `.Consumer` but such option might be less explicit.