### PR TITLE
Fix calculating orderline amount and order statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add order details page - #262 by @piotrgrundas
 - Add order confirmation page - #263 by @piotrgrundas
 - Fix checkout composition - #264 by @piotrgrundas
+- Fix rendering order statuses and order line prices - #281 by @maarcingebala
 
 ## 0.4.0
 

--- a/src/userAccount/views/OrderDetails/Page.tsx
+++ b/src/userAccount/views/OrderDetails/Page.tsx
@@ -19,8 +19,8 @@ const extractOrderLines = (
     .map(line => ({
       quantity: line.quantity,
       totalPrice: priceToString({
-        amount: line.quantity * line.variant.price.amount,
-        currency: line.variant.price.currency
+        amount: line.quantity * line.unitPrice.gross.amount,
+        currency: line.unitPrice.currency
       }),
       ...line.variant,
       name: line.productName
@@ -41,7 +41,7 @@ const Page: React.FC<{
       )}
       <h3>Your order nr: {order.number}</h3>
       <p className="order-details__status">
-        {order.paymentStatus} / {order.status}
+        {order.paymentStatusDisplay} / {order.statusDisplay}
       </p>
       <CartTable
         lines={extractOrderLines(order.lines)}

--- a/src/userAccount/views/OrderDetails/queries.ts
+++ b/src/userAccount/views/OrderDetails/queries.ts
@@ -5,7 +5,6 @@ import {
   checkoutAddressFragment,
   checkoutProductVariantFragment
 } from "../../../checkout/queries";
-import { Order, OrderVariables } from "./types/Order";
 import { OrderById, OrderByIdVariables } from "./types/OrderById";
 import { OrderByToken, OrderByTokenVariables } from "./types/OrderByToken";
 
@@ -24,7 +23,9 @@ const orderDetailFragment = gql`
   fragment OrderDetail on Order {
     userEmail
     paymentStatus
+    paymentStatusDisplay
     status
+    statusDisplay
     id
     number
     shippingAddress {
@@ -35,6 +36,12 @@ const orderDetailFragment = gql`
       quantity
       variant {
         ...ProductVariant
+      }
+      unitPrice {
+        currency
+        gross {
+          amount
+        }
       }
     }
     subtotal {

--- a/src/userAccount/views/OrderDetails/types/Order.ts
+++ b/src/userAccount/views/OrderDetails/types/Order.ts
@@ -1,7 +1,10 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { PaymentChargeStatusEnum, OrderStatus } from "./../../../../../types/globalTypes";
+import {
+  PaymentChargeStatusEnum,
+  OrderStatus
+} from "./../../../../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: Order

--- a/src/userAccount/views/OrderDetails/types/OrderById.ts
+++ b/src/userAccount/views/OrderDetails/types/OrderById.ts
@@ -103,11 +103,39 @@ export interface OrderById_order_lines_variant {
   product: OrderById_order_lines_variant_product;
 }
 
+export interface OrderById_order_lines_unitPrice_gross {
+  __typename: "Money";
+  /**
+   * Amount of money.
+   */
+  amount: number;
+}
+
+export interface OrderById_order_lines_unitPrice {
+  __typename: "TaxedMoney";
+  /**
+   * Currency code.
+   */
+  currency: string;
+  /**
+   * Amount of money including taxes.
+   */
+  gross: OrderById_order_lines_unitPrice_gross;
+}
+
 export interface OrderById_order_lines {
   __typename: "OrderLine";
   productName: string;
   quantity: number;
+  /**
+   * A purchased product variant. Note: this field may be null if the
+   * variant has been removed from stock at all.
+   */
   variant: OrderById_order_lines_variant | null;
+  /**
+   * Price of the single item in the order line.
+   */
+  unitPrice: OrderById_order_lines_unitPrice | null;
 }
 
 export interface OrderById_order_subtotal_gross {
@@ -168,7 +196,15 @@ export interface OrderById_order {
    * Internal payment status.
    */
   paymentStatus: PaymentChargeStatusEnum | null;
+  /**
+   * User-friendly payment status.
+   */
+  paymentStatusDisplay: string | null;
   status: OrderStatus;
+  /**
+   * User-friendly order status.
+   */
+  statusDisplay: string | null;
   /**
    * The ID of the object.
    */

--- a/src/userAccount/views/OrderDetails/types/OrderByToken.ts
+++ b/src/userAccount/views/OrderDetails/types/OrderByToken.ts
@@ -103,11 +103,39 @@ export interface OrderByToken_orderByToken_lines_variant {
   product: OrderByToken_orderByToken_lines_variant_product;
 }
 
+export interface OrderByToken_orderByToken_lines_unitPrice_gross {
+  __typename: "Money";
+  /**
+   * Amount of money.
+   */
+  amount: number;
+}
+
+export interface OrderByToken_orderByToken_lines_unitPrice {
+  __typename: "TaxedMoney";
+  /**
+   * Currency code.
+   */
+  currency: string;
+  /**
+   * Amount of money including taxes.
+   */
+  gross: OrderByToken_orderByToken_lines_unitPrice_gross;
+}
+
 export interface OrderByToken_orderByToken_lines {
   __typename: "OrderLine";
   productName: string;
   quantity: number;
+  /**
+   * A purchased product variant. Note: this field may be null if the
+   * variant has been removed from stock at all.
+   */
   variant: OrderByToken_orderByToken_lines_variant | null;
+  /**
+   * Price of the single item in the order line.
+   */
+  unitPrice: OrderByToken_orderByToken_lines_unitPrice | null;
 }
 
 export interface OrderByToken_orderByToken_subtotal_gross {
@@ -168,7 +196,15 @@ export interface OrderByToken_orderByToken {
    * Internal payment status.
    */
   paymentStatus: PaymentChargeStatusEnum | null;
+  /**
+   * User-friendly payment status.
+   */
+  paymentStatusDisplay: string | null;
   status: OrderStatus;
+  /**
+   * User-friendly order status.
+   */
+  statusDisplay: string | null;
   /**
    * The ID of the object.
    */

--- a/src/userAccount/views/OrderDetails/types/OrderDetail.ts
+++ b/src/userAccount/views/OrderDetails/types/OrderDetail.ts
@@ -103,11 +103,39 @@ export interface OrderDetail_lines_variant {
   product: OrderDetail_lines_variant_product;
 }
 
+export interface OrderDetail_lines_unitPrice_gross {
+  __typename: "Money";
+  /**
+   * Amount of money.
+   */
+  amount: number;
+}
+
+export interface OrderDetail_lines_unitPrice {
+  __typename: "TaxedMoney";
+  /**
+   * Currency code.
+   */
+  currency: string;
+  /**
+   * Amount of money including taxes.
+   */
+  gross: OrderDetail_lines_unitPrice_gross;
+}
+
 export interface OrderDetail_lines {
   __typename: "OrderLine";
   productName: string;
   quantity: number;
+  /**
+   * A purchased product variant. Note: this field may be null if the
+   * variant has been removed from stock at all.
+   */
   variant: OrderDetail_lines_variant | null;
+  /**
+   * Price of the single item in the order line.
+   */
+  unitPrice: OrderDetail_lines_unitPrice | null;
 }
 
 export interface OrderDetail_subtotal_gross {
@@ -168,7 +196,15 @@ export interface OrderDetail {
    * Internal payment status.
    */
   paymentStatus: PaymentChargeStatusEnum | null;
+  /**
+   * User-friendly payment status.
+   */
+  paymentStatusDisplay: string | null;
   status: OrderStatus;
+  /**
+   * User-friendly order status.
+   */
+  statusDisplay: string | null;
   /**
    * The ID of the object.
    */

--- a/types/globalTypes.ts
+++ b/types/globalTypes.ts
@@ -11,6 +11,8 @@
 export enum GatewaysEnum {
   BRAINTREE = "BRAINTREE",
   DUMMY = "DUMMY",
+  RAZORPAY = "RAZORPAY",
+  STRIPE = "STRIPE",
 }
 
 export enum OrderDirection {
@@ -33,9 +35,11 @@ export enum OrderStatus {
  * An enumeration.
  */
 export enum PaymentChargeStatusEnum {
-  CHARGED = "CHARGED",
+  FULLY_CHARGED = "FULLY_CHARGED",
   FULLY_REFUNDED = "FULLY_REFUNDED",
   NOT_CHARGED = "NOT_CHARGED",
+  PARTIALLY_CHARGED = "PARTIALLY_CHARGED",
+  PARTIALLY_REFUNDED = "PARTIALLY_REFUNDED",
 }
 
 export enum ProductOrderField {
@@ -74,7 +78,7 @@ export interface PaymentInput {
   gateway: GatewaysEnum;
   token: string;
   amount: any;
-  billingAddress: AddressInput;
+  billingAddress?: AddressInput | null;
 }
 
 export interface ProductOrder {


### PR DESCRIPTION
Instead of displaying raw statuses I changed the query to fetch "status displays". Also fixed calculating of order line amount which should rely on data returned by order line itself, not variant data.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.