### PR TITLE
Add redirect to 404 in case of incorrect page address

### DIFF
--- a/src/views/Article/View.tsx
+++ b/src/views/Article/View.tsx
@@ -3,7 +3,7 @@ import "./scss/index.scss";
 import * as React from "react";
 import { RouteComponentProps } from "react-router-dom";
 
-import { MetaWrapper } from "../../components";
+import { MetaWrapper, NotFound } from "../../components";
 import { STATIC_PAGES } from "../../core/config";
 import { generatePageUrl, maybe } from "../../core/utils";
 import Page from "./Page";
@@ -52,6 +52,10 @@ export const View: React.FC<ViewProps> = ({
             />
           </MetaWrapper>
         );
+      }
+
+      if (page === null) {
+        return <NotFound />;
       }
     }}
   </TypedArticleQuery>


### PR DESCRIPTION
I want to merge this change because...
it fixes #308 

When accessing https://pwa.getsaleor.com/page/whatever the page was crashing as "whateverpage" could not be queried and there was no redirect done for that particular case.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.