### PR TITLE
Add link for creating account for anonymous users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fix items number in cart based on total sum of quantities - #286 by @bogdandjukic
+- Add link for creating account for anonymous users - #317 by @mateuszkula
 
 ## 0.5.1
 

--- a/src/components/App/scss/_utils.scss
+++ b/src/components/App/scss/_utils.scss
@@ -14,4 +14,11 @@
   &uppercase {
     text-transform: uppercase;
   }
+
+  &link {
+    color: $blue;
+    font-weight: $bold-font-weight;
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }

--- a/src/components/CheckoutLogin/CheckoutAsGuest.tsx
+++ b/src/components/CheckoutLogin/CheckoutAsGuest.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { Link } from "react-router-dom";
+import { Button, OverlayTheme, OverlayType } from "..";
+
+const CheckoutAsGuest = ({ overlayContext, checkoutUrl }) => (
+  <div className="checkout-login__guest">
+    <h3 className="checkout__header">Continue as a guest</h3>
+    <p>
+      If you don’t want to register you account at our store don’t worry. You
+      can finish your checkout as a guest. You’ll be treated just as good as a
+      registered user.
+    </p>
+    <Link to={checkoutUrl}>
+      <Button>Continue as a guest</Button>
+    </Link>
+
+    <p>
+      or you can{" "}
+      <span
+        onClick={() =>
+          overlayContext.show(OverlayType.register, OverlayTheme.right)
+        }
+      >
+        create an account
+      </span>
+    </p>
+  </div>
+);
+
+export default CheckoutAsGuest;

--- a/src/components/CheckoutLogin/CheckoutAsGuest.tsx
+++ b/src/components/CheckoutLogin/CheckoutAsGuest.tsx
@@ -2,8 +2,12 @@ import React from "react";
 
 import { Link } from "react-router-dom";
 import { Button, OverlayTheme, OverlayType } from "..";
+import { OverlayContextInterface } from "../Overlay";
 
-const CheckoutAsGuest = ({ overlayContext, checkoutUrl }) => (
+const CheckoutAsGuest: React.FC<{
+  overlayContext: OverlayContextInterface;
+  checkoutUrl: string;
+}> = ({ overlayContext, checkoutUrl }) => (
   <div className="checkout-login__guest">
     <h3 className="checkout__header">Continue as a guest</h3>
     <p>

--- a/src/components/CheckoutLogin/CheckoutAsGuest.tsx
+++ b/src/components/CheckoutLogin/CheckoutAsGuest.tsx
@@ -5,9 +5,9 @@ import { Button, OverlayTheme, OverlayType } from "..";
 import { OverlayContextInterface } from "../Overlay";
 
 const CheckoutAsGuest: React.FC<{
-  overlayContext: OverlayContextInterface;
+  overlay: OverlayContextInterface;
   checkoutUrl: string;
-}> = ({ overlayContext, checkoutUrl }) => (
+}> = ({ overlay, checkoutUrl }) => (
   <div className="checkout-login__guest">
     <h3 className="checkout__header">Continue as a guest</h3>
     <p>
@@ -23,9 +23,7 @@ const CheckoutAsGuest: React.FC<{
       or you can{" "}
       <span
         className="u-link"
-        onClick={() =>
-          overlayContext.show(OverlayType.register, OverlayTheme.right)
-        }
+        onClick={() => overlay.show(OverlayType.register, OverlayTheme.right)}
       >
         create an account
       </span>

--- a/src/components/CheckoutLogin/CheckoutAsGuest.tsx
+++ b/src/components/CheckoutLogin/CheckoutAsGuest.tsx
@@ -11,9 +11,8 @@ const CheckoutAsGuest: React.FC<{
   <div className="checkout-login__guest">
     <h3 className="checkout__header">Continue as a guest</h3>
     <p>
-      If you don’t want to register you account at our store don’t worry. You
-      can finish your checkout as a guest. You’ll be treated just as good as a
-      registered user.
+      If you don’t wish to register an account, don’t worry. You can checkout as
+      a guest. We care about you just as good as any registered user.
     </p>
     <Link to={checkoutUrl}>
       <Button>Continue as a guest</Button>

--- a/src/components/CheckoutLogin/CheckoutAsGuest.tsx
+++ b/src/components/CheckoutLogin/CheckoutAsGuest.tsx
@@ -22,6 +22,7 @@ const CheckoutAsGuest: React.FC<{
     <p>
       or you can{" "}
       <span
+        className="u-link"
         onClick={() =>
           overlayContext.show(OverlayType.register, OverlayTheme.right)
         }

--- a/src/components/CheckoutLogin/ResetPasswordForm.tsx
+++ b/src/components/CheckoutLogin/ResetPasswordForm.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { PasswordResetForm } from "..";
+
+const ResetPasswordForm = ({ onClick }) => (
+  <>
+    <h3 className="checkout__header">Registered user</h3>
+    <PasswordResetForm />
+    <div className="login__content__password-reminder">
+      <p>
+        <span onClick={onClick}>Back to login</span>
+      </p>
+    </div>
+  </>
+);
+
+export default ResetPasswordForm;

--- a/src/components/CheckoutLogin/ResetPasswordForm.tsx
+++ b/src/components/CheckoutLogin/ResetPasswordForm.tsx
@@ -7,11 +7,11 @@ const ResetPasswordForm: React.FC<{
   <>
     <h3 className="checkout__header">Registered user</h3>
     <PasswordResetForm />
-    <div className="login__content__password-reminder">
-      <p>
-        <span onClick={onClick}>Back to login</span>
-      </p>
-    </div>
+    <p>
+      <span className="u-link" onClick={onClick}>
+        Back to login
+      </span>
+    </p>
   </>
 );
 

--- a/src/components/CheckoutLogin/ResetPasswordForm.tsx
+++ b/src/components/CheckoutLogin/ResetPasswordForm.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { PasswordResetForm } from "..";
 
-const ResetPasswordForm = ({ onClick }) => (
+const ResetPasswordForm: React.FC<{
+  onClick: () => void;
+}> = ({ onClick }) => (
   <>
     <h3 className="checkout__header">Registered user</h3>
     <PasswordResetForm />

--- a/src/components/CheckoutLogin/SignInForm.tsx
+++ b/src/components/CheckoutLogin/SignInForm.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { LoginForm } from "../";
 
-const SignInForm = ({ onClick }) => (
+const SignInForm: React.FC<{
+  onClick: () => void;
+}> = ({ onClick }) => (
   <>
     <h3 className="checkout__header">Registered user</h3>
     <LoginForm />

--- a/src/components/CheckoutLogin/SignInForm.tsx
+++ b/src/components/CheckoutLogin/SignInForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { LoginForm } from "../";
+import ForgottenPassword from "../OverlayManager/Login/ForgottenPassword";
 
 const SignInForm: React.FC<{
   onClick: () => void;
@@ -7,12 +8,7 @@ const SignInForm: React.FC<{
   <>
     <h3 className="checkout__header">Registered user</h3>
     <LoginForm />
-    <div className="login__content__password-reminder">
-      <p>
-        Have you forgotten your password?&nbsp;
-        <span onClick={onClick}>Click Here</span>
-      </p>
-    </div>
+    <ForgottenPassword onClick={onClick} />
   </>
 );
 

--- a/src/components/CheckoutLogin/SignInForm.tsx
+++ b/src/components/CheckoutLogin/SignInForm.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { LoginForm } from "../";
+
+const SignInForm = ({ onClick }) => (
+  <>
+    <h3 className="checkout__header">Registered user</h3>
+    <LoginForm />
+    <div className="login__content__password-reminder">
+      <p>
+        Have you forgotten your password?&nbsp;
+        <span onClick={onClick}>Click Here</span>
+      </p>
+    </div>
+  </>
+);
+
+export default SignInForm;

--- a/src/components/CheckoutLogin/index.tsx
+++ b/src/components/CheckoutLogin/index.tsx
@@ -1,6 +1,6 @@
 import "./scss/index.scss";
 
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { Redirect, RouteComponentProps } from "react-router";
 
 import { Offline, OfflinePlaceholder, Online, OverlayContext } from "..";
@@ -14,50 +14,37 @@ import SignInForm from "./SignInForm";
 
 const CheckoutLogin: React.FC<{}> = () => {
   const [resetPassword, setResetPassword] = useState(false);
+  const overlay = useContext(OverlayContext);
+  const user = useContext(UserContext);
+  if (user) {
+    return <Redirect to={checkoutUrl} />;
+  }
   return (
-    <OverlayContext.Consumer>
-      {overlayContext => {
-        return (
-          <UserContext.Consumer>
-            {({ user }) => {
-              if (user) {
-                return <Redirect to={checkoutUrl} />;
-              }
-              return (
-                <div className="container">
-                  <Online>
-                    <div className="checkout-login">
-                      <CheckoutAsGuest
-                        overlayContext={overlayContext}
-                        checkoutUrl={checkoutUrl}
-                      />
-                      <div className="checkout-login__user">
-                        {resetPassword ? (
-                          <ResetPasswordForm
-                            onClick={() => {
-                              setResetPassword(false);
-                            }}
-                          />
-                        ) : (
-                          <SignInForm
-                            onClick={() => {
-                              setResetPassword(true);
-                            }}
-                          />
-                        )}
-                      </div>
-                    </div>
-                  </Online>
-                  <Offline>
-                    <OfflinePlaceholder />
-                  </Offline>
-                </div>
-              );
-            }}
-          </UserContext.Consumer>
-        );
-      }}
-    </OverlayContext.Consumer>
+    <div className="container">
+      <Online>
+        <div className="checkout-login">
+          <CheckoutAsGuest overlay={overlay} checkoutUrl={checkoutUrl} />
+          <div className="checkout-login__user">
+            {resetPassword ? (
+              <ResetPasswordForm
+                onClick={() => {
+                  setResetPassword(false);
+                }}
+              />
+            ) : (
+              <SignInForm
+                onClick={() => {
+                  setResetPassword(true);
+                }}
+              />
+            )}
+          </div>
+        </div>
+      </Online>
+      <Offline>
+        <OfflinePlaceholder />
+      </Offline>
+    </div>
   );
 };
 

--- a/src/components/CheckoutLogin/index.tsx
+++ b/src/components/CheckoutLogin/index.tsx
@@ -2,22 +2,15 @@ import "./scss/index.scss";
 
 import * as React from "react";
 import { Redirect, RouteComponentProps } from "react-router";
-import { Link } from "react-router-dom";
 
-import {
-  Button,
-  LoginForm,
-  Offline,
-  OfflinePlaceholder,
-  Online,
-  OverlayContext,
-  OverlayTheme,
-  OverlayType,
-  PasswordResetForm
-} from "..";
+import { Offline, OfflinePlaceholder, Online, OverlayContext } from "..";
 
 import { baseUrl as checkoutUrl } from "../../checkout/routes";
 import { UserContext } from "../User/context";
+
+import CheckoutAsGuest from "./CheckoutAsGuest";
+import ResetPasswordForm from "./ResetPasswordForm";
+import SignInForm from "./SignInForm";
 
 class CheckoutLogin extends React.PureComponent<
   RouteComponentProps<{}>,
@@ -39,68 +32,23 @@ class CheckoutLogin extends React.PureComponent<
                   <div className="container">
                     <Online>
                       <div className="checkout-login">
-                        <div className="checkout-login__guest">
-                          <h3 className="checkout__header">
-                            Continue as a guest
-                          </h3>
-                          <p>
-                            If you don’t want to register you account at our
-                            store don’t worry. You can finish your checkout as a
-                            guest. You’ll be treated just as good as a
-                            registered user.
-                          </p>
-                          <Link to={checkoutUrl}>
-                            <Button>Continue as a guest</Button>
-                          </Link>
-
-                          <p>
-                            or you can{" "}
-                            <span
-                              onClick={() =>
-                                overlayContext.show(
-                                  OverlayType.register,
-                                  OverlayTheme.right
-                                )
-                              }
-                            >
-                              create an account
-                            </span>
-                          </p>
-                        </div>
+                        <CheckoutAsGuest
+                          overlayContext={overlayContext}
+                          checkoutUrl={checkoutUrl}
+                        />
                         <div className="checkout-login__user">
-                          <h3 className="checkout__header">Registered user</h3>
-
                           {this.state.resetPassword ? (
-                            <>
-                              <PasswordResetForm />
-                              <div className="login__content__password-reminder">
-                                <p>
-                                  <span
-                                    onClick={() =>
-                                      this.setState({ resetPassword: false })
-                                    }
-                                  >
-                                    Back to login
-                                  </span>
-                                </p>
-                              </div>
-                            </>
+                            <ResetPasswordForm
+                              onClick={() => {
+                                this.setState({ resetPassword: false });
+                              }}
+                            />
                           ) : (
-                            <>
-                              <LoginForm />
-                              <div className="login__content__password-reminder">
-                                <p>
-                                  Have you forgotten your password?&nbsp;
-                                  <span
-                                    onClick={() =>
-                                      this.setState({ resetPassword: true })
-                                    }
-                                  >
-                                    Click Here
-                                  </span>
-                                </p>
-                              </div>
-                            </>
+                            <SignInForm
+                              onClick={() => {
+                                this.setState({ resetPassword: true });
+                              }}
+                            />
                           )}
                         </div>
                       </div>

--- a/src/components/CheckoutLogin/index.tsx
+++ b/src/components/CheckoutLogin/index.tsx
@@ -1,6 +1,6 @@
 import "./scss/index.scss";
 
-import React, { useState, useContext } from "react";
+import React, { useContext, useState } from "react";
 import { Redirect, RouteComponentProps } from "react-router";
 
 import { Offline, OfflinePlaceholder, Online, OverlayContext } from "..";

--- a/src/components/CheckoutLogin/index.tsx
+++ b/src/components/CheckoutLogin/index.tsx
@@ -1,6 +1,6 @@
 import "./scss/index.scss";
 
-import * as React from "react";
+import React, { useState } from "react";
 import { Redirect, RouteComponentProps } from "react-router";
 
 import { Offline, OfflinePlaceholder, Online, OverlayContext } from "..";
@@ -12,59 +12,53 @@ import CheckoutAsGuest from "./CheckoutAsGuest";
 import ResetPasswordForm from "./ResetPasswordForm";
 import SignInForm from "./SignInForm";
 
-class CheckoutLogin extends React.PureComponent<
-  RouteComponentProps<{}>,
-  { resetPassword: boolean }
-> {
-  state = { resetPassword: false };
-
-  render() {
-    return (
-      <OverlayContext.Consumer>
-        {overlayContext => {
-          return (
-            <UserContext.Consumer>
-              {({ user }) => {
-                if (user) {
-                  return <Redirect to={checkoutUrl} />;
-                }
-                return (
-                  <div className="container">
-                    <Online>
-                      <div className="checkout-login">
-                        <CheckoutAsGuest
-                          overlayContext={overlayContext}
-                          checkoutUrl={checkoutUrl}
-                        />
-                        <div className="checkout-login__user">
-                          {this.state.resetPassword ? (
-                            <ResetPasswordForm
-                              onClick={() => {
-                                this.setState({ resetPassword: false });
-                              }}
-                            />
-                          ) : (
-                            <SignInForm
-                              onClick={() => {
-                                this.setState({ resetPassword: true });
-                              }}
-                            />
-                          )}
-                        </div>
+const CheckoutLogin: React.FC<{}> = () => {
+  const [resetPassword, setResetPassword] = useState(false);
+  return (
+    <OverlayContext.Consumer>
+      {overlayContext => {
+        return (
+          <UserContext.Consumer>
+            {({ user }) => {
+              if (user) {
+                return <Redirect to={checkoutUrl} />;
+              }
+              return (
+                <div className="container">
+                  <Online>
+                    <div className="checkout-login">
+                      <CheckoutAsGuest
+                        overlayContext={overlayContext}
+                        checkoutUrl={checkoutUrl}
+                      />
+                      <div className="checkout-login__user">
+                        {resetPassword ? (
+                          <ResetPasswordForm
+                            onClick={() => {
+                              setResetPassword(false);
+                            }}
+                          />
+                        ) : (
+                          <SignInForm
+                            onClick={() => {
+                              setResetPassword(true);
+                            }}
+                          />
+                        )}
                       </div>
-                    </Online>
-                    <Offline>
-                      <OfflinePlaceholder />
-                    </Offline>
-                  </div>
-                );
-              }}
-            </UserContext.Consumer>
-          );
-        }}
-      </OverlayContext.Consumer>
-    );
-  }
-}
+                    </div>
+                  </Online>
+                  <Offline>
+                    <OfflinePlaceholder />
+                  </Offline>
+                </div>
+              );
+            }}
+          </UserContext.Consumer>
+        );
+      }}
+    </OverlayContext.Consumer>
+  );
+};
 
 export default CheckoutLogin;

--- a/src/components/CheckoutLogin/index.tsx
+++ b/src/components/CheckoutLogin/index.tsx
@@ -15,8 +15,10 @@ import SignInForm from "./SignInForm";
 const CheckoutLogin: React.FC<{}> = () => {
   const [resetPassword, setResetPassword] = useState(false);
   const overlay = useContext(OverlayContext);
-  const user = useContext(UserContext);
+  const { user } = useContext(UserContext);
   if (user) {
+    // tslint:disable-next-line: no-console
+    console.log(user);
     return <Redirect to={checkoutUrl} />;
   }
   return (

--- a/src/components/CheckoutLogin/index.tsx
+++ b/src/components/CheckoutLogin/index.tsx
@@ -10,8 +10,12 @@ import {
   Offline,
   OfflinePlaceholder,
   Online,
+  OverlayContext,
+  OverlayTheme,
+  OverlayType,
   PasswordResetForm
 } from "..";
+
 import { baseUrl as checkoutUrl } from "../../checkout/routes";
 import { UserContext } from "../User/context";
 
@@ -23,71 +27,94 @@ class CheckoutLogin extends React.PureComponent<
 
   render() {
     return (
-      <UserContext.Consumer>
-        {({ user }) => {
-          if (user) {
-            return <Redirect to={checkoutUrl} />;
-          }
+      <OverlayContext.Consumer>
+        {overlayContext => {
           return (
-            <div className="container">
-              <Online>
-                <div className="checkout-login">
-                  <div className="checkout-login__guest">
-                    <h3 className="checkout__header">Continue as a guest</h3>
-                    <p>
-                      If you don’t want to register you account at our store
-                      don’t worry. You can finish your checkout as a guest.
-                      You’ll be treated just as good as a registered user.
-                    </p>
-                    <Link to={checkoutUrl}>
-                      <Button>Continue as a guest</Button>
-                    </Link>
-                  </div>
-                  <div className="checkout-login__user">
-                    <h3 className="checkout__header">Registered user</h3>
+            <UserContext.Consumer>
+              {({ user }) => {
+                if (user) {
+                  return <Redirect to={checkoutUrl} />;
+                }
+                return (
+                  <div className="container">
+                    <Online>
+                      <div className="checkout-login">
+                        <div className="checkout-login__guest">
+                          <h3 className="checkout__header">
+                            Continue as a guest
+                          </h3>
+                          <p>
+                            If you don’t want to register you account at our
+                            store don’t worry. You can finish your checkout as a
+                            guest. You’ll be treated just as good as a
+                            registered user.
+                          </p>
+                          <Link to={checkoutUrl}>
+                            <Button>Continue as a guest</Button>
+                          </Link>
 
-                    {this.state.resetPassword ? (
-                      <>
-                        <PasswordResetForm />
-                        <div className="login__content__password-reminder">
                           <p>
+                            or you can{" "}
                             <span
                               onClick={() =>
-                                this.setState({ resetPassword: false })
+                                overlayContext.show(
+                                  OverlayType.register,
+                                  OverlayTheme.right
+                                )
                               }
                             >
-                              Back to login
+                              create an account
                             </span>
                           </p>
                         </div>
-                      </>
-                    ) : (
-                      <>
-                        <LoginForm />
-                        <div className="login__content__password-reminder">
-                          <p>
-                            Have you forgotten your password?&nbsp;
-                            <span
-                              onClick={() =>
-                                this.setState({ resetPassword: true })
-                              }
-                            >
-                              Click Here
-                            </span>
-                          </p>
+                        <div className="checkout-login__user">
+                          <h3 className="checkout__header">Registered user</h3>
+
+                          {this.state.resetPassword ? (
+                            <>
+                              <PasswordResetForm />
+                              <div className="login__content__password-reminder">
+                                <p>
+                                  <span
+                                    onClick={() =>
+                                      this.setState({ resetPassword: false })
+                                    }
+                                  >
+                                    Back to login
+                                  </span>
+                                </p>
+                              </div>
+                            </>
+                          ) : (
+                            <>
+                              <LoginForm />
+                              <div className="login__content__password-reminder">
+                                <p>
+                                  Have you forgotten your password?&nbsp;
+                                  <span
+                                    onClick={() =>
+                                      this.setState({ resetPassword: true })
+                                    }
+                                  >
+                                    Click Here
+                                  </span>
+                                </p>
+                              </div>
+                            </>
+                          )}
                         </div>
-                      </>
-                    )}
+                      </div>
+                    </Online>
+                    <Offline>
+                      <OfflinePlaceholder />
+                    </Offline>
                   </div>
-                </div>
-              </Online>
-              <Offline>
-                <OfflinePlaceholder />
-              </Offline>
-            </div>
+                );
+              }}
+            </UserContext.Consumer>
           );
         }}
-      </UserContext.Consumer>
+      </OverlayContext.Consumer>
     );
   }
 }

--- a/src/components/CheckoutLogin/scss/index.scss
+++ b/src/components/CheckoutLogin/scss/index.scss
@@ -32,8 +32,15 @@
       color: $gray-dark;
     }
 
+    p > span {
+      color: $blue;
+      font-weight: $bold-font-weight;
+      text-decoration: underline;
+      cursor: pointer;
+    }
+
     button {
-      margin: $spacer * 2 0 0 $spacer * 2;
+      margin: $spacer * 2 0 $spacer * 2 $spacer * 2;
     }
   }
 

--- a/src/components/CheckoutLogin/scss/index.scss
+++ b/src/components/CheckoutLogin/scss/index.scss
@@ -32,13 +32,6 @@
       color: $gray-dark;
     }
 
-    p > span {
-      color: $blue;
-      font-weight: $bold-font-weight;
-      text-decoration: underline;
-      cursor: pointer;
-    }
-
     button {
       margin: $spacer * 2 0 $spacer * 2 $spacer * 2;
     }

--- a/src/components/Overlay/context.tsx
+++ b/src/components/Overlay/context.tsx
@@ -9,7 +9,8 @@ export enum OverlayType {
   password = "password",
   search = "search",
   mainMenuNav = "main-menu-nav",
-  modal = "modal"
+  modal = "modal",
+  register = "register"
 }
 
 export enum OverlayTheme {

--- a/src/components/OverlayManager/Login/ForgottenPassword.tsx
+++ b/src/components/OverlayManager/Login/ForgottenPassword.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const ForgottenPassword: React.FC<{
+  onClick: () => void;
+}> = ({ onClick }) => (
+  <>
+    <div className="login__content__password-reminder">
+      <p>
+        Have you forgotten your password?&nbsp;
+        <span className="u-link" onClick={onClick}>
+          Click Here
+        </span>
+      </p>
+    </div>
+  </>
+);
+
+export default ForgottenPassword;

--- a/src/components/OverlayManager/Login/index.tsx
+++ b/src/components/OverlayManager/Login/index.tsx
@@ -18,13 +18,16 @@ import RegisterForm from "./RegisterForm";
 import closeImg from "../../../images/x.svg";
 
 class Login extends React.Component<
-  { overlay: OverlayContextInterface },
+  { overlay: OverlayContextInterface; active?: "login" | "register" },
   { active: "login" | "register" }
 > {
+  static defaultProps = {
+    active: "login"
+  };
   constructor(props) {
     super(props);
     this.state = {
-      active: "login"
+      active: props.active
     };
   }
 

--- a/src/components/OverlayManager/Login/index.tsx
+++ b/src/components/OverlayManager/Login/index.tsx
@@ -16,6 +16,7 @@ import {
 import RegisterForm from "./RegisterForm";
 
 import closeImg from "../../../images/x.svg";
+import ForgottenPassword from "./ForgottenPassword";
 
 class Login extends React.Component<
   { overlay: OverlayContextInterface; active?: "login" | "register" },
@@ -69,18 +70,11 @@ class Login extends React.Component<
               {this.state.active === "login" ? (
                 <>
                   <LoginForm />
-                  <div className="login__content__password-reminder">
-                    <p>
-                      Have you forgotten your password?&nbsp;
-                      <span
-                        onClick={() =>
-                          show(OverlayType.password, OverlayTheme.right)
-                        }
-                      >
-                        Click Here
-                      </span>
-                    </p>
-                  </div>
+                  <ForgottenPassword
+                    onClick={() => {
+                      show(OverlayType.password, OverlayTheme.right);
+                    }}
+                  />
                 </>
               ) : (
                 <RegisterForm show={show} />

--- a/src/components/OverlayManager/Login/scss/index.scss
+++ b/src/components/OverlayManager/Login/scss/index.scss
@@ -49,13 +49,6 @@
       color: $gray;
       font-size: $small-font-size;
       margin-top: $spacer * 2;
-
-      span {
-        color: $blue;
-        font-weight: $bold-font-weight;
-        text-decoration: underline;
-        cursor: pointer;
-      }
     }
   }
 }

--- a/src/components/OverlayManager/Manager.tsx
+++ b/src/components/OverlayManager/Manager.tsx
@@ -28,6 +28,9 @@ const OverlayManager: React.FC = () => (
         case OverlayType.login:
           return <Login overlay={overlay} />;
 
+        case OverlayType.register:
+          return <Login overlay={overlay} active="register" />;
+
         case OverlayType.password:
           return <Password overlay={overlay} />;
 

--- a/src/components/PasswordResetForm/scss/index.scss
+++ b/src/components/PasswordResetForm/scss/index.scss
@@ -7,5 +7,6 @@
 
   &__button {
     text-align: center;
+    margin: $spacer * 2 0 $spacer * 2 $spacer * 2;
   }
 }


### PR DESCRIPTION
I want to merge this change because... it fixes #218 

<!-- Please mention all relevant issue numbers. -->

### Screenshots

"create an account" link has been added:

<img width="633" alt="Zrzut ekranu 2019-05-8 o 13 22 29" src="https://user-images.githubusercontent.com/30259869/57371932-74c9ee00-7194-11e9-93d2-5b5e778016aa.png">

I modified Login component so now it can accept prop for setting active tab - user is presented with **Register** tab when clicking "create an account" instead of **Sign in** tab

<img width="633" alt="Zrzut ekranu 2019-05-8 o 13 22 40" src="https://user-images.githubusercontent.com/30259869/57372032-beb2d400-7194-11e9-9786-c80705151063.png">



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.