### PR TITLE
fix issue #299 - display filters when no product was found

### DIFF
--- a/src/views/Category/Page.tsx
+++ b/src/views/Category/Page.tsx
@@ -67,24 +67,23 @@ const Page: React.FC<PageProps> = ({
       </div>
 
       {canDisplayProducts && (
-        <ProductFilters
-          filters={filters}
-          attributes={attributes}
-          onAttributeFiltersChange={onAttributeFiltersChange}
-          onPriceChange={onPriceChange}
-        />
-      )}
-
-      {canDisplayProducts && (
-        <ProductsList
-          displayLoader={displayLoader}
-          filters={filters}
-          hasNextPage={hasNextPage}
-          onLoadMore={onLoadMore}
-          onOrder={onOrder}
-          products={products.edges.map(edge => edge.node)}
-          totalCount={products.totalCount}
-        />
+        <>
+          <ProductFilters
+            filters={filters}
+            attributes={attributes}
+            onAttributeFiltersChange={onAttributeFiltersChange}
+            onPriceChange={onPriceChange}
+          />
+          <ProductsList
+            displayLoader={displayLoader}
+            filters={filters}
+            hasNextPage={hasNextPage}
+            onLoadMore={onLoadMore}
+            onOrder={onOrder}
+            products={products.edges.map(edge => edge.node)}
+            totalCount={products.totalCount}
+          />
+        </>
       )}
       {!hasProducts && <ProductsFeatured title="You might like" />}
     </div>

--- a/src/views/Category/Page.tsx
+++ b/src/views/Category/Page.tsx
@@ -66,7 +66,7 @@ const Page: React.FC<PageProps> = ({
         <Breadcrumbs breadcrumbs={extractBreadcrumbs(category)} />
       </div>
 
-      {hasProducts && (
+      {canDisplayProducts && (
         <ProductFilters
           filters={filters}
           attributes={attributes}

--- a/src/views/Search/index.tsx
+++ b/src/views/Search/index.tsx
@@ -118,13 +118,13 @@ export const SearchView: React.FC<SearchViewProps> = ({
                     return isOnline ? (
                       <Error error={error.message} />
                     ) : (
-                      <OfflinePlaceholder />
-                    );
+                        <OfflinePlaceholder />
+                      );
                   }
 
                   return (
                     <SearchPage onQueryChange={change} query={query}>
-                      {hasProducts && canDisplayFilters && (
+                      {canDisplayProducts && canDisplayFilters && (
                         <ProductFilters
                           attributes={data.attributes.edges.map(
                             edge => edge.node


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

Fixes #299 

### Screenshots

With this correction, when the filters don't match any product, the filters keep open and the user can correct it. The change affects 2 pages:

1) The "Search" page:
![image](https://user-images.githubusercontent.com/26613925/57387454-ba82b880-718c-11e9-8781-9eec81c9555e.png)

2) The "Categories" page:
![image](https://user-images.githubusercontent.com/26613925/57387594-0170ae00-718d-11e9-8414-04ebfc89e978.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [N/A] All visible strings are translated with proper context.
1. [N/A] All data-formatting is locale-aware (dates, numbers, and so on).
1. [X] The changes are tested.
1. [X ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.