### PR TITLE
[refactor] Adjust react component plop template

### DIFF
--- a/.plop/templates/reactComponent.tsx.hbs
+++ b/.plop/templates/reactComponent.tsx.hbs
@@ -7,7 +7,9 @@ import * as S from "./styles";
 {{/if}}
 import { IProps } from "./types";
 
-export const {{> p_componentName}}: React.FC<IProps> = () => {
+export const {{> p_componentName}}: React.FC<IProps> = ({
+  // destructure props here if needed
+}: IProps) => {
   return (
 {{#if componentHasStyles}}
     <S.Wrapper>


### PR DESCRIPTION
Adds explicit `Props` type on argument inside React component template. When destructuring inside argument, TS allows for any default value to be assigned resulting in an union type.