### PR TITLE
Add link to montserrat font so it works in storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link
+  href="https://fonts.googleapis.com/css?family=Montserrat:400,600,900&display=swap"
+  rel="stylesheet"
+/>

--- a/src/globalStyles/scss/variables.scss
+++ b/src/globalStyles/scss/variables.scss
@@ -26,7 +26,7 @@ $h1-line-height: 1;
 $h3-font-size: 1.5rem; // 24px
 $h4-font-size: 1.125rem; // 18px
 $bold-font-weight: 600;
-$extra-bold-font-weight: 800;
+$extra-bold-font-weight: 900;
 
 // spacing
 $spacer: 1rem; // 16px


### PR DESCRIPTION
I want to merge this change because...
Changes very bold font weight to 900 from 800 in template,
it adds montserrat font while using storybook.

Before
<img width="416" alt="obraz" src="https://user-images.githubusercontent.com/30259869/59609643-10e20000-9118-11e9-96dc-65f117238e76.png">

After:
<img width="416" alt="obraz" src="https://user-images.githubusercontent.com/30259869/59609547-e42de880-9117-11e9-8135-f7da9ce7ede4.png">
