### PR TITLE
Show image placeholders #489

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Adapt `checkout.availablePaymentGateways` structure to the new schema - #483 by @bogdal
 - Replace product/variant `price` fields with appropriate `pricing` fields - #483 by @bogdal
 - Add Stripe integration - #486 by @bogdal
+- Add PlaceholderImage component and show it in case of missing thumbnail - #489 by @xit4
 
 ## 0.6.0
 

--- a/src/@next/components/atoms/PlaceholderImage/PlaceholderImage.tsx
+++ b/src/@next/components/atoms/PlaceholderImage/PlaceholderImage.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 
+import { IProps } from "./types";
+
 import NoPhoto from "images/no-photo.svg";
 
-export const PlaceholderImage: React.FC = () => {
-  return <img src={NoPhoto} alt="placeholder" />;
+export const PlaceholderImage: React.FC<IProps> = ({
+  alt = "placeholder",
+}: IProps) => {
+  return <img src={NoPhoto} alt={alt} />;
 };

--- a/src/@next/components/atoms/PlaceholderImage/PlaceholderImage.tsx
+++ b/src/@next/components/atoms/PlaceholderImage/PlaceholderImage.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import NoPhoto from "images/no-photo.svg";
+
+export const PlaceholderImage: React.FC = () => {
+  return <img src={NoPhoto} alt="placeholder" />;
+};

--- a/src/@next/components/atoms/PlaceholderImage/index.ts
+++ b/src/@next/components/atoms/PlaceholderImage/index.ts
@@ -1,0 +1,1 @@
+export * from "./PlaceholderImage";

--- a/src/@next/components/atoms/PlaceholderImage/stories.tsx
+++ b/src/@next/components/atoms/PlaceholderImage/stories.tsx
@@ -1,0 +1,8 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { PlaceholderImage } from ".";
+
+storiesOf("@components/atoms/PlaceholderImage", module).add("default", () => (
+  <PlaceholderImage />
+));

--- a/src/@next/components/atoms/PlaceholderImage/types.ts
+++ b/src/@next/components/atoms/PlaceholderImage/types.ts
@@ -1,0 +1,3 @@
+export interface IProps {
+  alt?: string;
+}

--- a/src/@next/components/atoms/index.ts
+++ b/src/@next/components/atoms/index.ts
@@ -19,3 +19,4 @@ export * from "./NavLink";
 export * from "./ShadowBox";
 export * from "./Select";
 export * from "./Attribute";
+export * from "./PlaceholderImage";

--- a/src/@next/components/molecules/CachedImage/CachedImage.tsx
+++ b/src/@next/components/molecules/CachedImage/CachedImage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { PlaceholderImage } from "@components/atoms/PlaceholderImage";
+import { PlaceholderImage } from "@components/atoms";
 import { useNetworkStatus } from "@hooks";
 import NoPhoto from "images/no-photo.svg";
 

--- a/src/@next/components/molecules/CachedImage/CachedImage.tsx
+++ b/src/@next/components/molecules/CachedImage/CachedImage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { PlaceholderImage } from "@components/atoms/PlaceholderImage";
 import { useNetworkStatus } from "@hooks";
 import NoPhoto from "images/no-photo.svg";
 
@@ -41,7 +42,7 @@ export const CachedImage: React.FC<IProps> = ({
   }
 
   if (!url || isUnavailable) {
-    return children || <img src={defaultImage} alt="placeholder" />;
+    return children || <PlaceholderImage alt={alt} />;
   }
 
   return (

--- a/src/@next/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/src/@next/components/molecules/Thumbnail/Thumbnail.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { maybe } from "@utils/misc";
 
+import { PlaceholderImage } from "@components/atoms/PlaceholderImage";
 import { CachedImage } from "../";
 import { IProps } from "./types";
 
@@ -10,6 +11,9 @@ export const Thumbnail: React.FC<IProps> = ({
   children,
   ...props
 }: IProps) => {
+  if (!source.thumbnail && !source.thumbnail2x) {
+    return <PlaceholderImage/>;
+  }
   return (
     <CachedImage
       {...props}

--- a/src/@next/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/src/@next/components/molecules/Thumbnail/Thumbnail.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { maybe } from "@utils/misc";
 
-import { PlaceholderImage } from "@components/atoms/PlaceholderImage";
+import { PlaceholderImage } from "@components/atoms";
 import { CachedImage } from "../";
 import { IProps } from "./types";
 

--- a/src/@next/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/src/@next/components/molecules/Thumbnail/Thumbnail.tsx
@@ -12,7 +12,7 @@ export const Thumbnail: React.FC<IProps> = ({
   ...props
 }: IProps) => {
   if (!source.thumbnail && !source.thumbnail2x) {
-    return <PlaceholderImage/>;
+    return <PlaceholderImage />;
   }
   return (
     <CachedImage

--- a/src/components/ProductListItem/index.tsx
+++ b/src/components/ProductListItem/index.tsx
@@ -6,8 +6,6 @@ import { Thumbnail } from "@components/molecules";
 
 import { BasicProductFields } from "../../views/Product/types/BasicProductFields";
 
-import noPhotoImg from "../../images/no-photo.svg";
-
 export interface Product extends BasicProductFields {
   category?: {
     id: string;
@@ -42,9 +40,7 @@ const ProductListItem: React.FC<ProductListItemProps> = ({ product }) => {
   return (
     <div className="product-list-item">
       <div className="product-list-item__image">
-        <Thumbnail source={product}>
-          <img src={noPhotoImg} alt={product.thumbnail.alt} />
-        </Thumbnail>
+        <Thumbnail source={product} />
       </div>
       <h4 className="product-list-item__title">{product.name}</h4>
       <p className="product-list-item__category">{category.name}</p>

--- a/src/views/Product/View.tsx
+++ b/src/views/Product/View.tsx
@@ -38,7 +38,7 @@ const extractMeta = (product: ProductDetails_product) => ({
     },
   ],
   description: product.seoDescription || product.descriptionJson,
-  image: product.thumbnail.url,
+  image: maybe(() => product.thumbnail.url, null),
   title: product.seoTitle || product.name,
   type: "product.item",
   url: window.location.href,


### PR DESCRIPTION
I want to merge this change because...

I probably explained  the starting point of my work in [this comment](https://github.com/mirumee/saleor-storefront/issues/489#issuecomment-540053021) in issue #489 .

I created  a `PlaceholderImage` component that I replaced where `Thumbnail` and `CachedImage` were using it, trying to leave the existing logic unaffected and removing unnecessary _<img>_ tags.
`Thumbnail` now checks if the `thumbnail` object is defined and, in case it is not, it returns the `PlaceholderImage` directly without waiting for the exception to trigger `CachedImage`'s fallback

Fixes #489

### Screenshots

![image](https://user-images.githubusercontent.com/7601720/66500942-c0295500-eac2-11e9-9a1a-a66251ee405b.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.