### PR TITLE
Fix review order button for firefox

### DIFF
--- a/src/checkout/views/Payment/View.tsx
+++ b/src/checkout/views/Payment/View.tsx
@@ -199,7 +199,7 @@ class View extends React.Component<
                               disabled={loading}
                               onClick={() => {
                                 this.formRef.current.dispatchEvent(
-                                  new Event("submit")
+                                  new Event("submit", {cancelable: true})
                                 );
                               }}
                             >


### PR DESCRIPTION
I want to merge this change because...

Firefox will run default actions for 'submit' buttons unless it's told not to.
This means that the 'continue to review your order' will not work in Firefox and will instead refresh the page.

[See here](https://stackoverflow.com/questions/49587933/firefox-doesnt-preventing-dispatched-submit-event) for more.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.