### PR TITLE
Fix link pointing to demo instance for heroku deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
   "env": {
     "API_URI": {
       "description": "URI of a running instance of Saleor GraphQL API",
-      "value": "https://demo.getsaleor.com/graphql/"
+      "value": "https://pwa.demo.saleor.rocks/graphql/"
     }
   },
   "buildpacks": [


### PR DESCRIPTION
I want to merge this change because...

It fixes heroku deployment file. File was pointing to old url(`https://demo.getsaleor.com/graphql/`) but it should point to `https://pwa.demo.saleor.rocks/graphql/`