### PR TITLE
Remove email in checkout shipping for logged in user

### DIFF
--- a/src/checkout/components/AddressPicker/Picker.tsx
+++ b/src/checkout/components/AddressPicker/Picker.tsx
@@ -47,6 +47,7 @@ const renderModalForm = ({
   isVisibleModalForm,
   loading,
   type,
+  emailRequired,
 }: IAddressPickerProps) => (
   <Modal
     show={isVisibleModalForm}
@@ -62,6 +63,7 @@ const renderModalForm = ({
       loading={loading}
       errors={errors}
       onSubmit={handleAddressAdd}
+      emailRequired={emailRequired}
     />
   </Modal>
 );

--- a/src/checkout/components/UserAddressSelector/UserAddressSelector.tsx
+++ b/src/checkout/components/UserAddressSelector/UserAddressSelector.tsx
@@ -69,6 +69,10 @@ const UserAddressSelector: React.FC<UserAddressSelectorProps> = ({
   const updateAddresses = (address: FormAddressType) => {
     const isSelectedAsNew = address.asNew;
 
+    if (user.email) {
+      address.email = user.email;
+    }
+
     addAddressToList([...addressesList, address]);
     if (isSelectedAsNew) {
       uncheckShippingAsBilling();
@@ -94,6 +98,7 @@ const UserAddressSelector: React.FC<UserAddressSelectorProps> = ({
         onAddressSelect={handleAddressSelect}
         handleAddressAdd={handleAddressAdd}
         selectedAddress={selectedAddress}
+        emailRequired={!user.email}
         isVisibleModalForm={isVisibleModalForm}
         hideAddNewModalForm={hideAddModalForm}
         showAddNewModalForm={showAddModalForm}

--- a/src/checkout/types.ts
+++ b/src/checkout/types.ts
@@ -74,6 +74,7 @@ export interface IAddressPickerProps {
   isVisibleModalForm: boolean;
   loading: boolean;
   selectedAddress?: FormAddressType;
+  emailRequired?: boolean;
   onAddressSelect: (address: FormAddressType) => void;
   handleAddressAdd: (address: FormAddressType) => void;
   hideAddNewModalForm: () => void;

--- a/src/components/ShippingAddressForm/AddNewShippingAddressForm.tsx
+++ b/src/components/ShippingAddressForm/AddNewShippingAddressForm.tsx
@@ -15,7 +15,7 @@ export const AddNewShippingAddressForm: React.FC<IShippingNewAddressFormProps> =
   onSubmit,
   children,
   type,
-  noShipping = false,
+  emailRequired = true,
 }) => (
   <div className="address-form">
     <ShopContext.Consumer>
@@ -101,7 +101,7 @@ export const AddNewShippingAddressForm: React.FC<IShippingNewAddressFormProps> =
               }
             )}
           >
-            {type === "shipping" && (
+            {type === "shipping" && emailRequired && (
               <TextField
                 label="Email Address"
                 type="email"

--- a/src/components/ShippingAddressForm/types.ts
+++ b/src/components/ShippingAddressForm/types.ts
@@ -30,5 +30,5 @@ export interface IShippingAddressFormProps
 export interface IShippingNewAddressFormProps
   extends IBaseShippingAddressFormProps {
   onSubmit: (data: FormAddressType) => void;
-  noShipping?: boolean;
+  emailRequired?: boolean;
 }


### PR DESCRIPTION
I want to merge this change because... 
- it removes email field from checkout shipping form address addition modal if user is logged in,
- it takes instead automatically logged in user email and saves it in new address

Before:
![e0342ef9-2e83-4017-9ade-9d205f151d23](https://user-images.githubusercontent.com/9825562/74845558-7c2b4400-532f-11ea-9d84-ab5254b84036.png)

After:
![Zrzut ekranu 2020-02-19 o 15 45 53](https://user-images.githubusercontent.com/9825562/74845496-66b61a00-532f-11ea-83ad-b3656690c344.png)
