### PR TITLE
Preload css for Inter font

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,5 @@
-<link rel="preload" href="https://rsms.me/inter/inter.css" rel="stylesheet" />
+<link
+  rel="preconnect"
+  href="https://rsms.me/inter/inter.css"
+  rel="stylesheet"
+/>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
+<link rel="preload" href="https://rsms.me/inter/inter.css" rel="stylesheet" />

--- a/src/globalStyles/scss/index.scss
+++ b/src/globalStyles/scss/index.scss
@@ -1,5 +1,4 @@
 @import url("~reset-css");
-@import url("https://rsms.me/inter/inter.css");
 
 @import "./variables";
 @import "./utils";

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <title>Saleor</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="preload"
+      href="https://rsms.me/inter/inter.css"
+      rel="stylesheet"
+    />
     <script>
       if (window.Cypress) {
         window.__REACT_DEVTOOLS_GLOBAL_HOOK__ =

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <title>Saleor</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
-      rel="preload"
+      rel="preconnect"
       href="https://rsms.me/inter/inter.css"
       rel="stylesheet"
     />


### PR DESCRIPTION
I want to merge this change because... it adds preconnect to fetch css file describing required fonts. It will cause establish early connections to that file, what might be used in future rendering without blocking it due to required connection establishment.

Another improvement would be moving font source imports to Google fonts, although it is not yet available there due to not full support of this font rendering in modern browsers - https://github.com/google/fonts/pull/1908#issuecomment-580509162 - we might expect it in the future.
