### PR TITLE
Use sdk for fetching shop details

### DIFF
--- a/src/@sdk/index.ts
+++ b/src/@sdk/index.ts
@@ -103,6 +103,8 @@ export class SaleorAPI {
     data => data.productVariants
   );
 
+  getShopDetails = this.watchQuery(QUERIES.GetShopDetails, data => data);
+
   setUserDefaultAddress = this.fireQuery(
     MUTATIONS.AddressTypeUpdate,
     data => data!.accountSetDefaultAddress

--- a/src/@sdk/queries/index.ts
+++ b/src/@sdk/queries/index.ts
@@ -11,6 +11,7 @@ import * as Category from "./category";
 import * as Checkout from "./checkout";
 import * as Orders from "./orders";
 import * as Product from "./products";
+import * as Shop from "./shop";
 import * as WishlistQuery from "./wishlist";
 
 import {
@@ -31,6 +32,8 @@ import {
   CategoryDetails,
   CategoryDetailsVariables,
 } from "./types/CategoryDetails";
+
+import { GetShop } from "./types/GetShop";
 
 import { OrdersByUser, OrdersByUserVariables } from "./types/OrdersByUser";
 import { UserCheckoutDetails } from "./types/UserCheckoutDetails";
@@ -76,6 +79,16 @@ export const QUERIES = {
     client.watchQuery({
       query: gql`
         ${Checkout.checkoutDetails}
+      `,
+      ...options,
+    }),
+  GetShopDetails: <TCacheShape>(
+    client: ApolloClient<TCacheShape>,
+    options: QueryOptions<null>
+  ): ObservableQuery<GetShop, any> =>
+    client.watchQuery({
+      query: gql`
+        ${Shop.getShop}
       `,
       ...options,
     }),

--- a/src/@sdk/queries/shop.ts
+++ b/src/@sdk/queries/shop.ts
@@ -1,10 +1,7 @@
 import gql from "graphql-tag";
 
-import { TypedQuery } from "../../core/queries";
-import { getShop } from "./types/getShop";
-
-const getShopQuery = gql`
-  query getShop {
+export const getShop = gql`
+  query GetShop {
     shop {
       displayGrossPrices
       defaultCountry {
@@ -24,5 +21,3 @@ const getShopQuery = gql`
     }
   }
 `;
-
-export const TypedGetShopQuery = TypedQuery<getShop, {}>(getShopQuery);

--- a/src/@sdk/queries/types/GetShop.ts
+++ b/src/@sdk/queries/types/GetShop.ts
@@ -1,0 +1,78 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetShop
+// ====================================================
+
+export interface GetShop_shop_defaultCountry {
+  __typename: "CountryDisplay";
+  /**
+   * Country code.
+   */
+  code: string;
+  /**
+   * Country name.
+   */
+  country: string;
+}
+
+export interface GetShop_shop_countries {
+  __typename: "CountryDisplay";
+  /**
+   * Country name.
+   */
+  country: string;
+  /**
+   * Country code.
+   */
+  code: string;
+}
+
+export interface GetShop_shop_geolocalization_country {
+  __typename: "CountryDisplay";
+  /**
+   * Country code.
+   */
+  code: string;
+  /**
+   * Country name.
+   */
+  country: string;
+}
+
+export interface GetShop_shop_geolocalization {
+  __typename: "Geolocalization";
+  /**
+   * Country of the user acquired by his IP address.
+   */
+  country: GetShop_shop_geolocalization_country | null;
+}
+
+export interface GetShop_shop {
+  __typename: "Shop";
+  /**
+   * Display prices with tax in store.
+   */
+  displayGrossPrices: boolean;
+  /**
+   * Shop's default country.
+   */
+  defaultCountry: GetShop_shop_defaultCountry | null;
+  /**
+   * List of countries available in the shop.
+   */
+  countries: (GetShop_shop_countries | null)[];
+  /**
+   * Customer's geolocalization data.
+   */
+  geolocalization: GetShop_shop_geolocalization | null;
+}
+
+export interface GetShop {
+  /**
+   * Return information about the shop.
+   */
+  shop: GetShop_shop | null;
+}

--- a/src/@sdk/react/queries.ts
+++ b/src/@sdk/react/queries.ts
@@ -3,6 +3,8 @@ import { queryFactory, queryWithVariablesFactory } from "./useQuery";
 export const useProductDetails = queryWithVariablesFactory("getProductDetails");
 export const useProductList = queryWithVariablesFactory("getProductList");
 
+export const useShopDetails = queryFactory("getShopDetails");
+
 export const useUserDetails = queryFactory("getUserDetails");
 
 export const useUserCheckout = queryFactory("getUserCheckout");

--- a/src/components/ShopProvider/index.tsx
+++ b/src/components/ShopProvider/index.tsx
@@ -2,16 +2,16 @@ import * as React from "react";
 
 import { maybe } from "../../core/utils";
 import { defaultContext, ShopContext } from "./context";
-import { TypedGetShopQuery } from "./queries";
 
-const ShopProvider: React.FC = ({ children }) => (
-  <TypedGetShopQuery displayLoader={false} displayError={false}>
-    {({ data }) => (
-      <ShopContext.Provider value={maybe(() => data.shop, defaultContext)}>
-        {children}
-      </ShopContext.Provider>
-    )}
-  </TypedGetShopQuery>
-);
+import { useShopDetails } from "@sdk/react";
+
+const ShopProvider: React.FC = ({ children }) => {
+  const { data } = useShopDetails();
+  return (
+    <ShopContext.Provider value={maybe(() => data.shop, defaultContext)}>
+      {children}
+    </ShopContext.Provider>
+  );
+};
 
 export default ShopProvider;


### PR DESCRIPTION
I want to merge this change because...

It fixes landing page queries. Right now storefront was hitting backend with 2 graphql requests. Now it only uses 1.