### PR TITLE
Add .dockerignore file so you can build storefront with node modules present

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.dockerignore
 !.storybook
 !.gitignore
 !.babelrc


### PR DESCRIPTION
I want to merge this change because you cannot build the project using docker if you have already done `npm install` on host. Compose of platform will hang because too wide file context it's trying to send to docker daemon and it takes ages without need for that (`npm install` it's done within container anyway in both dockerfiles)

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.