### PR TITLE
Fix failing checkout review with digital products

### DIFF
--- a/src/checkout/views/Review/Summary.tsx
+++ b/src/checkout/views/Review/Summary.tsx
@@ -70,7 +70,7 @@ class Summary extends React.PureComponent<{
                 path={copyImg}
               />
             </h4>
-            <p>{checkout.shippingMethod.name}</p>
+            <p>{checkout.shippingMethod?.name}</p>
           </div>
         )}
         <div>

--- a/src/checkout/views/Review/View.tsx
+++ b/src/checkout/views/Review/View.tsx
@@ -84,7 +84,7 @@ const View: React.FC<RouteComponentProps<{ token?: string }>> = ({
             lines={extractCheckoutLines(checkout.lines)}
             subtotal={<TaxedMoney taxedMoney={checkout.subtotalPrice} />}
             deliveryCost={
-              <Money defaultValue="0" money={checkout.shippingMethod.price} />
+              <Money defaultValue="0" money={checkout.shippingMethod?.price} />
             }
             totalCost={<Money money={checkout.totalPrice.gross} />}
             discount={


### PR DESCRIPTION
I want to merge this change because... it fixes #628 app crash when product with no shopping method is available in checkout review.
