### PR TITLE
Remove translation information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,28 +79,6 @@ npm start
 
 Go to `http://localhost:3000` to access the storefront.
 
-### Translating
-
-Add a new language pack file:
-
-```
-npm run add-locale <locale>
-```
-
-Update the list of available languages in the `./src/languages.ts` file.
-
-Extract messages from source files that need to be translated:
-
-```
-npm run extract
-```
-
-Compile messages:
-
-```
-npm run compile
-```
-
 ## License
 
 This project is licensed under the BSD-3-Clause License - see the [LICENSE](https://github.com/mirumee/saleor-storefront/blob/master/LICENSE) file for details


### PR DESCRIPTION
I want to merge this change because...

it removes information which is not valid anymore(about translations) from README.md file