### PR TITLE
Unregister service worker for Cypress

### DIFF
--- a/src/@next/hooks/useServiceWorker.tsx
+++ b/src/@next/hooks/useServiceWorker.tsx
@@ -18,8 +18,12 @@ export const useServiceWorker = ({ timeout = 1000 }) => {
   const updated = () => setUpdateAvailable(true);
 
   React.useEffect(() => {
-    register("/service-worker.js", { registered, updated });
-    return () => unregister();
+    if (window.Cypress) {
+      unregister();
+    } else {
+      register("/service-worker.js", { registered, updated });
+      return () => unregister();
+    }
   }, []);
 
   return { updateAvailable };

--- a/src/@sdk/global.d.ts
+++ b/src/@sdk/global.d.ts
@@ -1,5 +1,6 @@
 declare interface Window {
   PasswordCredential: any;
+  Cypress?: any;
 }
 
 declare interface Navigator {

--- a/webpack.d.ts
+++ b/webpack.d.ts
@@ -13,6 +13,7 @@ declare module "query-string";
 // This was copied from src/@sdk/global.d.ts to make TS compiler happy
 declare interface Window {
   PasswordCredential: any;
+  Cypress?: any;
 }
 
 declare interface Navigator {


### PR DESCRIPTION
I want to merge this change because... it unregisters service worker to run properly Cypress tests.
