### PR TITLE
Send ID instead Name of plugin on CreatePayment request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Make checkout working without shipping if it is not required - #571 by @orzechdev
 - Add ability to apply a promo code in checkout - #582 by @orzechdev
 - Add docs to storybook - #614 by @orzechdev
+- Send ID instead Name of plugin on CreatePayment request - #680 by @gabmartinez
 
 ## 0.7.0
 
@@ -89,4 +90,3 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add OpenGraph and Meta tags - #191 by @piotrgrundas
 - Add `tslint` check on CI; add the ability to change cart quantity - #194 by @piotrgrundas
 - Update placeholder for missing image - #198 by @piotrgrundas
-- Send ID instead Name of plugin on CreatePayment request - #680 by @gabmartinez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add OpenGraph and Meta tags - #191 by @piotrgrundas
 - Add `tslint` check on CI; add the ability to change cart quantity - #194 by @piotrgrundas
 - Update placeholder for missing image - #198 by @piotrgrundas
+- Send ID instead Name of plugin on CreatePayment request - #680 by @gabmartinez

--- a/src/checkout/views/Payment/Gateways/Braintree/CreditCard.tsx
+++ b/src/checkout/views/Payment/Gateways/Braintree/CreditCard.tsx
@@ -75,7 +75,7 @@ const CreditCard = ({
         number: removeEmptySpaces(maybe(() => formData.ccNumber, "")),
       };
       const token = await tokenizeCcCard(creditCard);
-      processPayment(token, PROVIDERS.BRAINTREE.label);
+      processPayment(token, PROVIDERS.BRAINTREE.id);
       setLoadingState(false);
     };
 

--- a/src/checkout/views/Payment/Gateways/Dummy.tsx
+++ b/src/checkout/views/Payment/Gateways/Dummy.tsx
@@ -30,7 +30,7 @@ class Dummy extends React.PureComponent<
         onSubmit={async evt => {
           evt.preventDefault();
           await update({ dummyStatus: selectedStatus.label });
-          processPayment(selectedStatus.token, PROVIDERS.DUMMY.label);
+          processPayment(selectedStatus.token, PROVIDERS.DUMMY.id);
         }}
         className="c-option__content"
       >

--- a/src/checkout/views/Payment/Gateways/Stripe/CardForm.tsx
+++ b/src/checkout/views/Payment/Gateways/Stripe/CardForm.tsx
@@ -36,7 +36,7 @@ const CardForm = ({
           token: id,
         },
       });
-      processPayment(id, PROVIDERS.STRIPE.label);
+      processPayment(id, PROVIDERS.STRIPE.id);
     }
     setLoadingState(false);
   };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -5,17 +5,17 @@ export const PRODUCTS_PER_PAGE = 6;
 export const SUPPORT_EMAIL = "support@example.com";
 export const PROVIDERS = {
   BRAINTREE: {
-    label: "Braintree",
     id: "mirumee.payments.braintree",
+    label: "Braintree",
   },
   DUMMY: {
-    label: "Dummy",
     id: "Stmirumee.payments.dummy",
+    label: "Dummy",
   },
   STRIPE: {
     href: "https://js.stripe.com/v3/",
-    label: "Stripe",
     id: "mirumee.payments.stripe",
+    label: "Stripe",
   },
 };
 export const STATIC_PAGES = [

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,13 +6,16 @@ export const SUPPORT_EMAIL = "support@example.com";
 export const PROVIDERS = {
   BRAINTREE: {
     label: "Braintree",
+    id: "mirumee.payments.braintree",
   },
   DUMMY: {
     label: "Dummy",
+    id: "Stmirumee.payments.dummy",
   },
   STRIPE: {
     href: "https://js.stripe.com/v3/",
     label: "Stripe",
+    id: "mirumee.payments.stripe",
   },
 };
 export const STATIC_PAGES = [

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -9,7 +9,7 @@ export const PROVIDERS = {
     label: "Braintree",
   },
   DUMMY: {
-    id: "Stmirumee.payments.dummy",
+    id: "mirumee.payments.dummy",
     label: "Dummy",
   },
   STRIPE: {


### PR DESCRIPTION
I want to merge this change because it uses the plugin id instead of name when sending CreatePayment request. The API was updated and it expected the id, the change was applied in this PR: [#5528](https://github.com/mirumee/saleor/pull/5528)

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<img width="350" alt="Screen Shot 2020-04-30 at 6 51 49 PM" src="https://user-images.githubusercontent.com/24206382/80766590-c4c36280-8b13-11ea-8127-6d768de4eed4.png">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.