### PR TITLE
Fix cart sidebar prices

### DIFF
--- a/src/components/OverlayManager/Cart/Cart.tsx
+++ b/src/components/OverlayManager/Cart/Cart.tsx
@@ -5,7 +5,7 @@ import { generatePath, Link } from "react-router-dom";
 import ReactSVG from "react-svg";
 
 import { TaxedMoney } from "@components/containers";
-import { useCart, useUserDetails } from "@sdk/react";
+import { useCart, useCheckout, useUserDetails } from "@sdk/react";
 
 import {
   Button,
@@ -24,7 +24,27 @@ import closeImg from "../../../images/x.svg";
 
 const Cart: React.FC<{ overlay: OverlayContextInterface }> = ({ overlay }) => {
   const { data: user } = useUserDetails();
-  const { items, removeItem, subtotalPrice } = useCart();
+  const { checkout } = useCheckout();
+  const {
+    items,
+    removeItem,
+    subtotalPrice,
+    shippingPrice,
+    discount,
+    totalPrice,
+  } = useCart();
+
+  const shippingTaxedPrice =
+    checkout?.shippingMethod?.id && shippingPrice
+      ? {
+          gross: shippingPrice,
+          net: shippingPrice,
+        }
+      : null;
+  const promoTaxedPrice = discount && {
+    gross: discount,
+    net: discount,
+  };
 
   return (
     <Overlay context={overlay}>
@@ -52,13 +72,46 @@ const Cart: React.FC<{ overlay: OverlayContextInterface }> = ({ overlay }) => {
             <>
               <ProductList lines={items} remove={removeItem} />
               <div className="cart__footer">
-                <div className="cart__footer__subtotoal">
+                <div className="cart__footer__price">
                   <span>Subtotal</span>
-
                   <span>
                     <TaxedMoney
                       data-cy="cartPageSubtotalPrice"
                       taxedMoney={subtotalPrice}
+                    />
+                  </span>
+                </div>
+
+                {shippingTaxedPrice && shippingTaxedPrice.gross.amount !== 0 && (
+                  <div className="cart__footer__price">
+                    <span>Shipping</span>
+                    <span>
+                      <TaxedMoney
+                        data-cy="cartPageShippingPrice"
+                        taxedMoney={shippingTaxedPrice}
+                      />
+                    </span>
+                  </div>
+                )}
+
+                {promoTaxedPrice && promoTaxedPrice.gross.amount !== 0 && (
+                  <div className="cart__footer__price">
+                    <span>Promo code</span>
+                    <span>
+                      <TaxedMoney
+                        data-cy="cartPagePromoCodePrice"
+                        taxedMoney={promoTaxedPrice}
+                      />
+                    </span>
+                  </div>
+                )}
+
+                <div className="cart__footer__price">
+                  <span>Total</span>
+                  <span>
+                    <TaxedMoney
+                      data-cy="cartPageTotalPrice"
+                      taxedMoney={totalPrice}
                     />
                   </span>
                 </div>

--- a/src/components/OverlayManager/Cart/scss/index.scss
+++ b/src/components/OverlayManager/Cart/scss/index.scss
@@ -80,9 +80,10 @@
     bottom: 0;
     width: 25rem;
 
-    &__subtotoal {
+    &__price {
       display: flex;
       padding-bottom: $spacer;
+      margin-bottom: $spacer;
       text-transform: uppercase;
       font-weight: $bold-font-weight;
       justify-content: space-between;


### PR DESCRIPTION
I want to merge this change because it adds missing shipping and total prices, as well as promo code discount to cart sidebar. If shipping and promo code is not available, then it will be hidden.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

![Zrzut ekranu 2020-05-5 o 19 06 45](https://user-images.githubusercontent.com/9825562/81095826-d5098200-8f05-11ea-86a3-3c48b2bec1a7.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.