### PR TITLE
Disable keyboard opening when selecting product variant

### DIFF
--- a/src/@next/components/organisms/ProductVariantPicker/ProductVariantAttributeSelect.tsx
+++ b/src/@next/components/organisms/ProductVariantPicker/ProductVariantAttributeSelect.tsx
@@ -113,6 +113,7 @@ export const ProductVariantAttributeSelect: React.FC<{
           value={selectedValue ? selectedValue.value : ""}
           onChange={() => null}
           contentRight={getRightInputContent(!!selectedValue)}
+          readOnly={true}
         />
         <SelectSidebar
           options={attributeOptions}


### PR DESCRIPTION
I want to merge this change because it disables undesired keyboard opening on mobile devices when selecting product variant attribute.

<!-- Please mention all relevant issue numbers. -->

### Screenshots
#### Before
- iOS
![image](https://user-images.githubusercontent.com/9825562/81286411-4f9ae480-9061-11ea-9aec-894b76fcf7c2.png)
- Android
![image](https://user-images.githubusercontent.com/9825562/81286485-6d684980-9061-11ea-9f0a-a87089b143d9.png)

#### After
- iOS
![image](https://user-images.githubusercontent.com/9825562/81286435-59244c80-9061-11ea-8d02-6a4d51ba82e0.png)
- Android
![image](https://user-images.githubusercontent.com/9825562/81286519-78bb7500-9061-11ea-91aa-d4565de88b78.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.