### PR TITLE
Register service worker only if it is built

### DIFF
--- a/config/webpack/config.base.js
+++ b/config/webpack/config.base.js
@@ -113,7 +113,6 @@ module.exports = ({ sourceDir, distDir }) => ({
     }),
     new webpack.EnvironmentPlugin({
       API_URI: "http://localhost:8000/graphql/",
-      SERVICE_WORKER_TIMEOUT: "60000",
     }),
   ],
   node: {

--- a/config/webpack/config.worker.js
+++ b/config/webpack/config.worker.js
@@ -1,12 +1,23 @@
 const path = require("path");
 const WorkboxPlugin = require("workbox-webpack-plugin");
+const webpack = require("webpack");
 
 module.exports = ({ sourceDir, distDir }) => ({
   plugins: [
     new WorkboxPlugin.InjectManifest({
       swSrc: `${sourceDir}/sw.js`,
-      swDest: path.join(distDir, './service-worker.js'),
-      exclude: [/\.map$/, /^manifest.*\.js(?:on)?$/, /\.js.map$/, /\.css.map/, /\.xls$/]
-    })
-  ]
+      swDest: path.join(distDir, "./service-worker.js"),
+      exclude: [
+        /\.map$/,
+        /^manifest.*\.js(?:on)?$/,
+        /\.js.map$/,
+        /\.css.map/,
+        /\.xls$/,
+      ],
+    }),
+    new webpack.EnvironmentPlugin({
+      SERVICE_WORKER_EXISTS: true,
+      SERVICE_WORKER_TIMEOUT: "60000",
+    }),
+  ],
 });

--- a/src/@next/hooks/useServiceWorker.tsx
+++ b/src/@next/hooks/useServiceWorker.tsx
@@ -18,7 +18,7 @@ export const useServiceWorker = ({ timeout = 1000 }) => {
   const updated = () => setUpdateAvailable(true);
 
   React.useEffect(() => {
-    if (window.Cypress) {
+    if (window.Cypress || !process.env.SERVICE_WORKER_EXISTS) {
       unregister();
     } else {
       register("/service-worker.js", { registered, updated });


### PR DESCRIPTION
I want to merge this change because it fixes #674, by registering service worker only if it built with webpack.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.