### PR TITLE
Do not use prettier on generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !.jest
 !.linguirc
 !.prettierrc
+!.prettierignore
 dist
 node_modules
 src/locales/_build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+gqlTypes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Use sdk as a standalone package - #724 by @dominik-zeglen
 - Fix CartRow tests - #749 by @dominik-zeglen
 - Add prettier to precommit - #766 by @dominik-zeglen
+- Do not use prettier on generated files - #773 by @dominik-zeglen
 
 ## 2.10.2
 

--- a/src/components/Footer/gqlTypes/SecondaryMenu.ts
+++ b/src/components/Footer/gqlTypes/SecondaryMenu.ts
@@ -82,9 +82,7 @@ export interface SecondaryMenu_shop_navigation_secondary_items {
   url: string | null;
   collection: SecondaryMenu_shop_navigation_secondary_items_collection | null;
   page: SecondaryMenu_shop_navigation_secondary_items_page | null;
-  children:
-    | (SecondaryMenu_shop_navigation_secondary_items_children | null)[]
-    | null;
+  children: (SecondaryMenu_shop_navigation_secondary_items_children | null)[] | null;
 }
 
 export interface SecondaryMenu_shop_navigation_secondary {

--- a/src/components/MainMenu/gqlTypes/MainMenu.ts
+++ b/src/components/MainMenu/gqlTypes/MainMenu.ts
@@ -131,9 +131,7 @@ export interface MainMenu_shop_navigation_main_items_children {
   collection: MainMenu_shop_navigation_main_items_children_collection | null;
   page: MainMenu_shop_navigation_main_items_children_page | null;
   parent: MainMenu_shop_navigation_main_items_children_parent | null;
-  children:
-    | (MainMenu_shop_navigation_main_items_children_children | null)[]
-    | null;
+  children: (MainMenu_shop_navigation_main_items_children_children | null)[] | null;
 }
 
 export interface MainMenu_shop_navigation_main_items {

--- a/src/views/Category/gqlTypes/Category.ts
+++ b/src/views/Category/gqlTypes/Category.ts
@@ -2,10 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import {
-  AttributeInput,
-  ProductOrder,
-} from "./../../../../gqlTypes/globalTypes";
+import { AttributeInput, ProductOrder } from "./../../../../gqlTypes/globalTypes";
 
 // ====================================================
 // GraphQL query operation: Category
@@ -388,7 +385,7 @@ export interface Category {
    */
   products: Category_products | null;
   /**
-   * Look up a category by ID.
+   * Look up a category by ID or slug.
    */
   category: Category_category | null;
   /**

--- a/src/views/Collection/gqlTypes/Collection.ts
+++ b/src/views/Collection/gqlTypes/Collection.ts
@@ -2,10 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import {
-  AttributeInput,
-  ProductOrder,
-} from "./../../../../gqlTypes/globalTypes";
+import { AttributeInput, ProductOrder } from "./../../../../gqlTypes/globalTypes";
 
 // ====================================================
 // GraphQL query operation: Collection

--- a/src/views/Search/gqlTypes/SearchProducts.ts
+++ b/src/views/Search/gqlTypes/SearchProducts.ts
@@ -2,10 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import {
-  AttributeInput,
-  ProductOrder,
-} from "./../../../../gqlTypes/globalTypes";
+import { AttributeInput, ProductOrder } from "./../../../../gqlTypes/globalTypes";
 
 // ====================================================
 // GraphQL query operation: SearchProducts


### PR DESCRIPTION
I want to merge this change because it prevents prettier from linting generated files.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.