### PR TITLE
Add use of filterableInStorefront in Sidebar

### DIFF
--- a/src/views/Category/queries.ts
+++ b/src/views/Category/queries.ts
@@ -64,7 +64,10 @@ export const categoryProductsQuery = gql`
         }
       }
     }
-    attributes(filter: { inCategory: $id }, first: 100) {
+    attributes(
+      filter: { inCategory: $id, filterableInStorefront: true }
+      first: 100
+    ) {
       edges {
         node {
           id

--- a/src/views/Collection/queries.ts
+++ b/src/views/Collection/queries.ts
@@ -57,7 +57,10 @@ export const collectionProductsQuery = gql`
         startCursor
       }
     }
-    attributes(filter: { inCollection: $id }, first: 100) {
+    attributes(
+      filter: { inCollection: $id, filterableInStorefront: true }
+      first: 100
+    ) {
       edges {
         node {
           id

--- a/src/views/Search/queries.ts
+++ b/src/views/Search/queries.ts
@@ -46,7 +46,7 @@ export const searchProductsQuery = gql`
         hasNextPage
       }
     }
-    attributes(first: 100) {
+    attributes(filter: { filterableInStorefront: true }, first: 100) {
       edges {
         node {
           id


### PR DESCRIPTION
I want to merge this change because... it makes use of the `filterableInStorefront` configuration parameter and presents only selected filters in storefronts sidebar.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
