### PR TITLE
Do not throw error if unsupported payment gateway found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update sdk to newest version - #795 by @dominik-zeglen
 - Use intl - #782 by @przlada
 - Download invoice for order - #790 by @orzechdev
+- Do not throw error if unsupported payment gateway found - #819 by @dominik-zeglen
 
 ## 2.10.4
 

--- a/src/@next/components/organisms/PaymentGatewaysList/PaymentGatewaysList.tsx
+++ b/src/@next/components/organisms/PaymentGatewaysList/PaymentGatewaysList.tsx
@@ -130,7 +130,7 @@ const PaymentGatewaysList: React.FC<IProps> = ({
             );
 
           default:
-            throw new Error("Unsupported payment gateway");
+            return null;
         }
       })}
       {!selectedPaymentGateway && errors && <ErrorMessage errors={errors} />}


### PR DESCRIPTION
I want to merge this change because it handles payment gateways that are unsupported simply by omitting them.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
