### PR TITLE
Fix tsconfig aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Use intl - #782 by @przlada
 - Download invoice for order - #790 by @orzechdev
 - Do not throw error if unsupported payment gateway found - #819 by @dominik-zeglen
+- Fix tsconfig aliases - #824 by @orzechdev
 
 ## 2.10.4
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,6 @@
     "target": "es6",
     "noUnusedLocals": true,
     "paths": {
-      "@temp/*": ["./src/*"],
-      "@app/*": ["./src/@next/*"],
       "@components/*": ["./src/@next/components/*"],
       "@components/atoms": ["./src/@next/components/atoms/index.ts"],
       "@components/molecules": ["./src/@next/components/molecules/index.ts"],
@@ -25,7 +23,10 @@
       "@hooks": ["./src/@next/hooks/index.ts"],
       "@hooks/*": ["./src/@next/hooks/*"],
       "@types": ["./src/@next/types/index.ts"],
-      "@locale/*": ["./locale/*"]
+      "@types/*": ["./src/@next/types/*"],
+      "@app/*": ["./src/@next/*"],
+      "@locale/*": ["./locale/*"],
+      "@temp/*": ["./src/*"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true


### PR DESCRIPTION
I want to merge this change because... it helps VS Code to auto-import with shorter aliases, by moving less nested paths down in the tsconfig paths:
instead of autoimport from `@temp/@next/types` just do it from `@types`.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
