### PR TITLE
Hoist payment gateways for the whole checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Do not throw error if unsupported payment gateway found - #819 by @dominik-zeglen
 - Fix tsconfig aliases - #824 by @orzechdev
 - Set billing address in first checkout step - #822 by @orzechdev
+- Persist payment gateways for the whole checkout - #828 by @orzechdev
 
 ## 2.10.4
 

--- a/src/@next/components/organisms/CheckoutPayment/CheckoutPayment.tsx
+++ b/src/@next/components/organisms/CheckoutPayment/CheckoutPayment.tsx
@@ -14,18 +14,13 @@ import { IProps } from "./types";
  * Payment options used in checkout.
  */
 const CheckoutPayment: React.FC<IProps> = ({
-  gatewayErrors,
   promoCodeErrors,
-  paymentGateways,
   promoCodeDiscountFormId,
   promoCodeDiscountFormRef,
   promoCodeDiscount,
   addPromoCode,
   removeVoucherCode,
   submitUnchangedDiscount,
-  selectPaymentGateway,
-  processPayment,
-  onGatewayError,
 }: IProps) => {
   const [showPromoCodeForm, setShowPromoCodeForm] = useState(
     !!promoCodeDiscount?.voucherCode

--- a/src/@next/components/organisms/CheckoutPayment/CheckoutPayment.tsx
+++ b/src/@next/components/organisms/CheckoutPayment/CheckoutPayment.tsx
@@ -6,7 +6,6 @@ import { checkoutMessages } from "@temp/intl";
 
 import { DiscountForm } from "../DiscountForm";
 import { IDiscountFormData } from "../DiscountForm/types";
-import { PaymentGatewaysList } from "../PaymentGatewaysList";
 
 import * as S from "./styles";
 import { IProps } from "./types";
@@ -24,11 +23,7 @@ const CheckoutPayment: React.FC<IProps> = ({
   addPromoCode,
   removeVoucherCode,
   submitUnchangedDiscount,
-  selectedPaymentGateway,
-  selectedPaymentGatewayToken,
   selectPaymentGateway,
-  gatewayFormRef,
-  gatewayFormId,
   processPayment,
   onGatewayError,
 }: IProps) => {
@@ -86,17 +81,6 @@ const CheckoutPayment: React.FC<IProps> = ({
           </S.DiscountField>
         )}
         <S.Divider />
-        <PaymentGatewaysList
-          errors={gatewayErrors}
-          paymentGateways={paymentGateways}
-          formRef={gatewayFormRef}
-          formId={gatewayFormId}
-          processPayment={processPayment}
-          selectedPaymentGateway={selectedPaymentGateway}
-          selectedPaymentGatewayToken={selectedPaymentGatewayToken}
-          selectPaymentGateway={selectPaymentGateway}
-          onError={onGatewayError}
-        />
       </section>
     </S.Wrapper>
   );

--- a/src/@next/components/organisms/CheckoutPayment/__snapshots__/stories.storyshot
+++ b/src/@next/components/organisms/CheckoutPayment/__snapshots__/stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots @components/organisms/CheckoutPayment default 1`] = `
   margin: 20px;
 }
 
-.c9 {
+.c6 {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -105,39 +105,6 @@ exports[`Storyshots @components/organisms/CheckoutPayment default 1`] = `
   background-color: rgb(33,18,94);
 }
 
-.c8 {
-  cursor: pointer;
-}
-
-.c8 input[type="radio"] {
-  opacity: 0;
-  position: fixed;
-  width: 0;
-}
-
-.c8 > div {
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  margin: 0.25em 1em 0.25em 0.25em;
-  border: 0.1em solid #21125e;
-  border-radius: 0.5em;
-  background: #ffffff;
-  vertical-align: bottom;
-}
-
-.c6 {
-  display: grid;
-  grid-gap: 20px;
-}
-
-.c7 {
-  display: block;
-  background-color: #f1f5f5;
-  padding: 20px;
-  cursor: pointer;
-}
-
 .c5 {
   width: 100%;
   border-bottom: 1px solid rgba(50,50,50,0.1);
@@ -189,72 +156,10 @@ exports[`Storyshots @components/organisms/CheckoutPayment default 1`] = `
       <div
         className="c5"
       />
-      <div
-        className="c6"
-      >
-        <div>
-          <label
-            checked={false}
-            className="c7"
-          >
-            <div
-              checked={false}
-              className="c8"
-            >
-              <input
-                checked={false}
-                data-test="checkoutPaymentGatewayDummyInput"
-                name="payment-method"
-                onChange={[Function]}
-                type="radio"
-                value="dummy"
-              />
-               
-              <div>
-                <span />
-              </div>
-              <span
-                data-test="checkoutPaymentGatewayDummyName"
-              >
-                Dummy
-              </span>
-            </div>
-          </label>
-        </div>
-        <div>
-          <label
-            checked={false}
-            className="c7"
-          >
-            <div
-              checked={false}
-              className="c8"
-            >
-              <input
-                checked={false}
-                data-test="checkoutPaymentGatewayStripeInput"
-                name="payment-method"
-                onChange={[Function]}
-                type="radio"
-                value="stripe"
-              />
-               
-              <div>
-                <span />
-              </div>
-              <span
-                data-test="checkoutPaymentGatewayStripeName"
-              >
-                Stripe
-              </span>
-            </div>
-          </label>
-        </div>
-      </div>
     </section>
   </div>
   <div
-    className="c9"
+    className="c6"
   />
 </div>
 `;

--- a/src/@next/components/organisms/CheckoutPayment/stories.tsx
+++ b/src/@next/components/organisms/CheckoutPayment/stories.tsx
@@ -18,9 +18,6 @@ const removeVoucherCode = action("removeVoucherCode has been called");
 const submitUnchangedDiscount = action(
   "submitUnchangedDiscount has been called"
 );
-const selectPaymentGateway = action("selectPaymentGateway has been called");
-const processPayment = action("processPayment has been called");
-const onGatewayError = action("onGatewayError has been called");
 
 storiesOf("@components/organisms/CheckoutPayment", module)
   .addParameters({ component: CheckoutPayment })
@@ -31,9 +28,6 @@ storiesOf("@components/organisms/CheckoutPayment", module)
         addPromoCode={addPromoCode}
         removeVoucherCode={removeVoucherCode}
         submitUnchangedDiscount={submitUnchangedDiscount}
-        selectPaymentGateway={selectPaymentGateway}
-        processPayment={processPayment}
-        onGatewayError={onGatewayError}
       />
     </IntlProvider>
   ));

--- a/src/@next/components/organisms/CheckoutPayment/test.tsx
+++ b/src/@next/components/organisms/CheckoutPayment/test.tsx
@@ -11,9 +11,6 @@ describe("<CheckoutPayment />", () => {
     const addPromoCode = jest.fn();
     const removeVoucherCode = jest.fn();
     const submitUnchangedDiscount = jest.fn();
-    const selectPaymentGateway = jest.fn();
-    const processPayment = jest.fn();
-    const onGatewayError = jest.fn();
     const wrapper = mount(
       <IntlProvider locale="en">
         <CheckoutPayment
@@ -21,9 +18,6 @@ describe("<CheckoutPayment />", () => {
           addPromoCode={addPromoCode}
           removeVoucherCode={removeVoucherCode}
           submitUnchangedDiscount={submitUnchangedDiscount}
-          selectPaymentGateway={selectPaymentGateway}
-          processPayment={processPayment}
-          onGatewayError={onGatewayError}
         />
       </IntlProvider>
     );

--- a/src/@next/components/organisms/CheckoutPayment/test.tsx
+++ b/src/@next/components/organisms/CheckoutPayment/test.tsx
@@ -28,8 +28,6 @@ describe("<CheckoutPayment />", () => {
       </IntlProvider>
     );
 
-    const wrapperText = wrapper.text();
-    expect(wrapperText).toContain(PROPS.paymentGateways[0].name);
-    expect(wrapperText).toContain(PROPS.paymentGateways[1].name);
+    expect(wrapper.exists()).toEqual(true);
   });
 });

--- a/src/@next/components/organisms/CheckoutPayment/types.ts
+++ b/src/@next/components/organisms/CheckoutPayment/types.ts
@@ -1,33 +1,15 @@
-import { ICardData, IFormError, IPaymentGateway } from "@types";
+import { IFormError } from "@types";
 
 export interface IPromoCodeDiscount {
   voucherCode?: string | null;
 }
 
 export interface IProps {
-  gatewayErrors?: IFormError[];
   promoCodeErrors?: IFormError[];
-  paymentGateways: IPaymentGateway[];
   promoCodeDiscount?: IPromoCodeDiscount;
   promoCodeDiscountFormRef?: React.RefObject<HTMLFormElement>;
   promoCodeDiscountFormId?: string;
   addPromoCode: (promoCode: string) => void;
   removeVoucherCode: (voucherCode: string) => void;
   submitUnchangedDiscount: () => void;
-  /**
-   * Called when selected payment gateway is changed.
-   */
-  selectPaymentGateway: (paymentGateway: string) => void;
-  /**
-   * Method called after the form is submitted. Passed gateway id and token attribute will be used to create payment.
-   */
-  processPayment: (
-    gateway: string,
-    token: string,
-    cardData?: ICardData
-  ) => void;
-  /**
-   * Method called when gateway error occured.
-   */
-  onGatewayError: (errors: IFormError[]) => void;
 }

--- a/src/@next/components/organisms/CheckoutPayment/types.ts
+++ b/src/@next/components/organisms/CheckoutPayment/types.ts
@@ -15,22 +15,9 @@ export interface IProps {
   removeVoucherCode: (voucherCode: string) => void;
   submitUnchangedDiscount: () => void;
   /**
-   * Selected payment gateway.
-   */
-  selectedPaymentGateway?: string;
-  /**
-   * Selected payment gateway token.
-   */
-  selectedPaymentGatewayToken?: string;
-  /**
    * Called when selected payment gateway is changed.
    */
   selectPaymentGateway: (paymentGateway: string) => void;
-  /**
-   * Gateway form reference on which payment might be submitted.
-   */
-  gatewayFormRef?: React.RefObject<HTMLFormElement>;
-  gatewayFormId?: string;
   /**
    * Method called after the form is submitted. Passed gateway id and token attribute will be used to create payment.
    */

--- a/src/@next/components/templates/Checkout/Checkout.tsx
+++ b/src/@next/components/templates/Checkout/Checkout.tsx
@@ -14,6 +14,8 @@ const Checkout: React.FC<IProps> = ({
   loading,
   navigation,
   checkout,
+  paymentGateways,
+  hidePaymentGateways = false,
   cartSummary,
   button,
 }: IProps) => {
@@ -27,6 +29,9 @@ const Checkout: React.FC<IProps> = ({
       <S.Wrapper>
         <S.Navigation>{navigation}</S.Navigation>
         <S.Checkout>{checkout}</S.Checkout>
+        <S.PaymentGateways hide={hidePaymentGateways}>
+          {paymentGateways}
+        </S.PaymentGateways>
         <S.CartSummary>{cartSummary}</S.CartSummary>
         <S.Button>{button}</S.Button>
       </S.Wrapper>

--- a/src/@next/components/templates/Checkout/__snapshots__/stories.storyshot
+++ b/src/@next/components/templates/Checkout/__snapshots__/stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots @components/templates/Checkout default 1`] = `
   margin: 20px;
 }
 
-.c7 {
+.c8 {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -30,7 +30,7 @@ exports[`Storyshots @components/templates/Checkout default 1`] = `
   grid-template-columns: 8fr 4fr;
   grid-template-rows: 85px auto auto;
   grid-column-gap: 30px;
-  grid-template-areas: "navigation cartSummary" "checkout cartSummary" "button cartSummary";
+  grid-template-areas: "navigation cartSummary" "checkout cartSummary" "paymentGateways cartSummary" "button cartSummary";
 }
 
 .c3 {
@@ -42,15 +42,20 @@ exports[`Storyshots @components/templates/Checkout default 1`] = `
 
 .c4 {
   grid-area: checkout;
-  padding: 3rem 0;
+  padding: 3rem 0 0 0;
 }
 
 .c5 {
-  grid-area: cartSummary;
+  grid-area: paymentGateways;
 }
 
 .c6 {
+  grid-area: cartSummary;
+}
+
+.c7 {
   grid-area: button;
+  margin: 3rem 0 0 0;
 }
 
 @media (max-width:992px) {
@@ -62,12 +67,12 @@ exports[`Storyshots @components/templates/Checkout default 1`] = `
 @media (max-width:720px) {
   .c2 {
     grid-template-columns: 1fr;
-    grid-template-areas: "navigation" "checkout" "button";
+    grid-template-areas: "navigation" "checkout" "paymentGateways" "button";
   }
 }
 
 @media (max-width:720px) {
-  .c5 {
+  .c6 {
     position: fixed;
     bottom: 0;
   }
@@ -84,20 +89,83 @@ exports[`Storyshots @components/templates/Checkout default 1`] = `
     >
       <div
         className="c3"
-      />
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#ccc",
+              "border": "1px solid black",
+              "padding": "10px",
+            }
+          }
+        >
+          Navigation
+        </div>
+      </div>
       <div
         className="c4"
-      />
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#ccc",
+              "border": "1px solid black",
+              "padding": "10px",
+            }
+          }
+        >
+          Checkout
+        </div>
+      </div>
       <div
         className="c5"
-      />
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#ccc",
+              "border": "1px solid black",
+              "padding": "10px",
+            }
+          }
+        >
+          Payment gateways
+        </div>
+      </div>
       <div
         className="c6"
-      />
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#ccc",
+              "border": "1px solid black",
+              "padding": "10px",
+            }
+          }
+        >
+          Cart summary
+        </div>
+      </div>
+      <div
+        className="c7"
+      >
+        <button
+          style={
+            Object {
+              "backgroundColor": "#ccc",
+              "border": "1px solid black",
+              "padding": "10px",
+            }
+          }
+        >
+          Button
+        </button>
+      </div>
     </div>
   </div>
   <div
-    className="c7"
+    className="c8"
   />
 </div>
 `;

--- a/src/@next/components/templates/Checkout/stories.tsx
+++ b/src/@next/components/templates/Checkout/stories.tsx
@@ -3,6 +3,26 @@ import React from "react";
 
 import { Checkout } from ".";
 
+const style = {
+  backgroundColor: "#ccc",
+  border: "1px solid black",
+  padding: "10px",
+};
+
+const navigation = <div style={style}>Navigation</div>;
+const checkout = <div style={style}>Checkout</div>;
+const paymentGateways = <div style={style}>Payment gateways</div>;
+const cartSummary = <div style={style}>Cart summary</div>;
+const button = <button style={style}>Button</button>;
+
 storiesOf("@components/templates/Checkout", module)
   .addParameters({ component: Checkout })
-  .add("default", () => <Checkout />);
+  .add("default", () => (
+    <Checkout
+      navigation={navigation}
+      checkout={checkout}
+      paymentGateways={paymentGateways}
+      cartSummary={cartSummary}
+      button={button}
+    />
+  ));

--- a/src/@next/components/templates/Checkout/styles.ts
+++ b/src/@next/components/templates/Checkout/styles.ts
@@ -20,6 +20,7 @@ export const Wrapper = styled.div`
   grid-template-areas:
     "navigation cartSummary"
     "checkout cartSummary"
+    "paymentGateways cartSummary"
     "button cartSummary";
 
   ${media.mediumScreen`
@@ -27,6 +28,7 @@ export const Wrapper = styled.div`
     grid-template-areas:
       "navigation"
       "checkout"
+      "paymentGateways"
       "button";
   `}
 `;
@@ -40,7 +42,11 @@ export const Navigation = styled.div`
 `;
 export const Checkout = styled.div`
   grid-area: checkout;
-  padding: 3rem 0;
+  padding: 3rem 0 0 0;
+`;
+export const PaymentGateways = styled.div<{ hide: boolean }>`
+  ${props => props.hide && "display: none;"}
+  grid-area: paymentGateways;
 `;
 export const CartSummary = styled.div`
   grid-area: cartSummary;
@@ -52,4 +58,5 @@ export const CartSummary = styled.div`
 `;
 export const Button = styled.div`
   grid-area: button;
+  margin: 3rem 0 0 0;
 `;

--- a/src/@next/components/templates/Checkout/types.ts
+++ b/src/@next/components/templates/Checkout/types.ts
@@ -2,6 +2,8 @@ export interface IProps {
   loading?: boolean;
   navigation?: React.ReactNode;
   checkout?: React.ReactNode;
+  paymentGateways?: React.ReactNode;
+  hidePaymentGateways?: boolean;
   cartSummary?: React.ReactNode;
   button?: React.ReactNode;
 }

--- a/src/@next/pages/CheckoutPage/CheckoutPage.tsx
+++ b/src/@next/pages/CheckoutPage/CheckoutPage.tsx
@@ -4,7 +4,7 @@ import { Redirect, useLocation, useHistory } from "react-router-dom";
 
 import { Button, Loader } from "@components/atoms";
 import { CheckoutProgressBar } from "@components/molecules";
-import { CartSummary } from "@components/organisms";
+import { CartSummary, PaymentGatewaysList } from "@components/organisms";
 import { Checkout } from "@components/templates";
 import { useCart, useCheckout } from "@saleor/sdk";
 import { IItems } from "@saleor/sdk/lib/api/Cart/types";
@@ -101,7 +101,12 @@ const CheckoutPage: React.FC<IProps> = ({}: IProps) => {
     totalPrice,
     items,
   } = useCart();
-  const { loaded: checkoutLoaded, checkout, payment } = useCheckout();
+  const {
+    loaded: checkoutLoaded,
+    checkout,
+    payment,
+    availablePaymentGateways,
+  } = useCheckout();
   const intl = useIntl();
 
   if (cartLoaded && (!items || !items?.length)) {
@@ -151,6 +156,8 @@ const CheckoutPage: React.FC<IProps> = ({}: IProps) => {
     null
   );
   const checkoutReviewSubpageRef = useRef<ICheckoutReviewSubpageHandles>(null);
+  const checkoutGatewayFormId = "gateway-form";
+  const checkoutGatewayFormRef = useRef<HTMLFormElement>(null);
 
   const handleNextStepClick = () => {
     // Some magic above and below ensures that the activeStepIndex will always
@@ -227,8 +234,6 @@ const CheckoutPage: React.FC<IProps> = ({}: IProps) => {
         renderPayment={props => (
           <CheckoutPaymentSubpage
             ref={checkoutPaymentSubpageRef}
-            selectedPaymentGateway={selectedPaymentGateway}
-            selectedPaymentGatewayToken={selectedPaymentGatewayToken}
             changeSubmitProgress={setSubmitInProgress}
             selectPaymentGateway={setSelectedPaymentGateway}
             onSubmitSuccess={handleStepSubmitSuccess}
@@ -248,6 +253,20 @@ const CheckoutPage: React.FC<IProps> = ({}: IProps) => {
     ) : (
       <Loader />
     );
+
+  // TODO: handle payment gateways callbacks
+  const paymentGatewaysView = availablePaymentGateways && (
+    <PaymentGatewaysList
+      paymentGateways={availablePaymentGateways}
+      processPayment={() => undefined}
+      formId={checkoutGatewayFormId}
+      formRef={checkoutGatewayFormRef}
+      selectedPaymentGateway={selectedPaymentGateway}
+      selectedPaymentGatewayToken={selectedPaymentGatewayToken}
+      selectPaymentGateway={() => undefined}
+      onError={() => undefined}
+    />
+  );
 
   let buttonText = activeStep.nextActionName;
   /* eslint-disable default-case */
@@ -282,6 +301,8 @@ const CheckoutPage: React.FC<IProps> = ({}: IProps) => {
         items
       )}
       checkout={checkoutView}
+      paymentGateways={paymentGatewaysView}
+      hidePaymentGateways={steps[activeStepIndex].name !== "Payment"}
       button={getButton(buttonText.toUpperCase(), handleNextStepClick)}
     />
   );

--- a/src/@next/pages/CheckoutPage/subpages/CheckoutPaymentSubpage.tsx
+++ b/src/@next/pages/CheckoutPage/subpages/CheckoutPaymentSubpage.tsx
@@ -17,8 +17,7 @@ export interface ICheckoutPaymentSubpageHandles {
   submitPayment: () => void;
 }
 interface IProps extends RouteComponentProps<any> {
-  selectedPaymentGateway?: string;
-  selectedPaymentGatewayToken?: string;
+  paymentGatewayFormRef?: React.RefObject<HTMLFormElement>;
   selectPaymentGateway: (paymentGateway: string) => void;
   changeSubmitProgress: (submitInProgress: boolean) => void;
   onSubmitSuccess: () => void;
@@ -29,8 +28,7 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
   IProps
 > = (
   {
-    selectedPaymentGateway,
-    selectedPaymentGatewayToken,
+    paymentGatewayFormRef,
     changeSubmitProgress,
     selectPaymentGateway,
     onSubmitSuccess,
@@ -51,8 +49,6 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
 
   const paymentGateways = availablePaymentGateways || [];
 
-  const checkoutGatewayFormId = "gateway-form";
-  const checkoutGatewayFormRef = useRef<HTMLFormElement>(null);
   const promoCodeDiscountFormId = "discount-form";
   const promoCodeDiscountFormRef = useRef<HTMLFormElement>(null);
   const intl = useIntl();
@@ -63,8 +59,8 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
         promoCodeDiscountFormRef.current?.dispatchEvent(
           new Event("submit", { cancelable: true })
         );
-      } else if (checkoutGatewayFormRef.current) {
-        checkoutGatewayFormRef.current.dispatchEvent(
+      } else if (paymentGatewayFormRef?.current) {
+        paymentGatewayFormRef.current.dispatchEvent(
           new Event("submit", { cancelable: true })
         );
       } else {
@@ -102,8 +98,8 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
       setPromoCodeErrors(errors);
     } else {
       setPromoCodeErrors([]);
-      if (checkoutGatewayFormRef.current) {
-        checkoutGatewayFormRef.current.dispatchEvent(
+      if (paymentGatewayFormRef?.current) {
+        paymentGatewayFormRef.current.dispatchEvent(
           new Event("submit", { cancelable: true })
         );
       } else {
@@ -122,8 +118,8 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
       setPromoCodeErrors(errors);
     } else {
       setPromoCodeErrors([]);
-      if (checkoutGatewayFormRef.current) {
-        checkoutGatewayFormRef.current.dispatchEvent(
+      if (paymentGatewayFormRef?.current) {
+        paymentGatewayFormRef.current.dispatchEvent(
           new Event("submit", { cancelable: true })
         );
       } else {
@@ -135,8 +131,8 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
     }
   };
   const handleSubmitUnchangedDiscount = () => {
-    if (checkoutGatewayFormRef.current) {
-      checkoutGatewayFormRef.current.dispatchEvent(
+    if (paymentGatewayFormRef?.current) {
+      paymentGatewayFormRef.current.dispatchEvent(
         new Event("submit", { cancelable: true })
       );
     } else {
@@ -152,8 +148,6 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
       {...props}
       gatewayErrors={gatewayErrors}
       paymentGateways={paymentGateways}
-      selectedPaymentGateway={selectedPaymentGateway}
-      selectedPaymentGatewayToken={selectedPaymentGatewayToken}
       selectPaymentGateway={selectPaymentGateway}
       promoCodeDiscountFormId={promoCodeDiscountFormId}
       promoCodeDiscountFormRef={promoCodeDiscountFormRef}
@@ -164,8 +158,6 @@ const CheckoutPaymentSubpageWithRef: RefForwardingComponent<
       removeVoucherCode={handleRemovePromoCode}
       submitUnchangedDiscount={handleSubmitUnchangedDiscount}
       promoCodeErrors={promoCodeErrors}
-      gatewayFormId={checkoutGatewayFormId}
-      gatewayFormRef={checkoutGatewayFormRef}
       processPayment={handleProcessPayment}
       onGatewayError={handlePaymentGatewayError}
     />


### PR DESCRIPTION
I want to merge this change because... it makes payment gateways persisted for all the checkout steps and hides them through CSS if they shouldn't be displayed.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
