### PR TITLE
Do not cache csv and pdf in service worker

### DIFF
--- a/config/webpack/config.worker.js
+++ b/config/webpack/config.worker.js
@@ -13,6 +13,8 @@ module.exports = ({ sourceDir, distDir }) => ({
         /\.js.map$/,
         /\.css.map/,
         /\.xls$/,
+        /\.pdf$/,
+        /\.csv$/,
       ],
     }),
     new webpack.EnvironmentPlugin({

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -15,8 +15,6 @@ import { SearchPage } from "../../views/Search";
 
 import * as paths from "./paths";
 
-const reload = () => window.location.reload();
-
 export const Routes: React.FC = () => (
   <Switch>
     <Route exact path={paths.baseUrl} component={HomePage} />
@@ -37,7 +35,6 @@ export const Routes: React.FC = () => (
     <Route path={paths.passwordResetUrl} component={PasswordReset} />
     <Route path={paths.checkoutUrl} component={CheckoutPage} />
     <Route path={paths.orderFinalizedUrl} component={ThankYouPage} />
-    <Route path="/media/*" onEnter={reload} />
     <Route component={NotFound} />
   </Switch>
 );

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -15,6 +15,8 @@ import { SearchPage } from "../../views/Search";
 
 import * as paths from "./paths";
 
+const reload = () => window.location.reload();
+
 export const Routes: React.FC = () => (
   <Switch>
     <Route exact path={paths.baseUrl} component={HomePage} />
@@ -35,6 +37,7 @@ export const Routes: React.FC = () => (
     <Route path={paths.passwordResetUrl} component={PasswordReset} />
     <Route path={paths.checkoutUrl} component={CheckoutPage} />
     <Route path={paths.orderFinalizedUrl} component={ThankYouPage} />
+    <Route path="/media/*" onEnter={reload} />
     <Route component={NotFound} />
   </Switch>
 );

--- a/src/sw.js
+++ b/src/sw.js
@@ -10,13 +10,17 @@ workbox.core.setCacheNameDetails({
 workbox.precaching.precacheAndRoute(self.__precacheManifest || []);
 
 workbox.routing.registerRoute(
-  new RegExp("^http.*(?:png|gif|jpg|jpeg|webp|svg)"),
+  new RegExp("^http.*(?:png|gif|jpg|jpeg|webp|svg|csv|pdf)"),
   new workbox.strategies.NetworkFirst()
 );
 
 workbox.routing.registerNavigationRoute(
   workbox.precaching.getCacheKeyForURL("/index.html"),
   {
-    blacklist: [new RegExp("/graphql"), new RegExp("/dashboard")],
+    blacklist: [
+      new RegExp("/graphql"),
+      new RegExp("/dashboard"),
+      new RegExp("/media/export_files"),
+    ],
   }
 );


### PR DESCRIPTION
I want to merge this change because...
storefront is hijacking csv files export.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
