### PR TITLE
Properly resolve file extensions for building with npm run build

### DIFF
--- a/config/webpack/config.prod.js
+++ b/config/webpack/config.prod.js
@@ -19,6 +19,9 @@ module.exports = ({ sourceDir, distDir }) => ({
       }
     ]
   },
+  resolve: { 
+    extensions: ['.ts', '.tsx', '.js', '.jsx'] 
+  },
   plugins: [
     new MiniCssExtractPlugin({
       filename: "[name].[hash].css",


### PR DESCRIPTION
Building the storefront image for production with Dockerfile would fail with a bunch of errors like: 

```
`ERROR in ./src/index.tsx
Module not found: Error: Can't resolve '@saleor/sdk' in '/app/src'
```
Adding resolve to the webpack prod config allows for the storefront to be built without error, and run in production. The resolve extensions currently exist in the dashboard production build config, but was missing in the storefront.

Current Issues posted with this problem: #843

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
