### PR TITLE
fix page shift when navbar is used

### DIFF
--- a/src/globalStyles/scss/index.scss
+++ b/src/globalStyles/scss/index.scss
@@ -9,6 +9,8 @@ body {
   font-size: $base-font-size;
   line-height: $base-line-height;
   color: $base-font-color;
+  overflow-x: hidden;
+  margin-right: calc(-1 * (100vw - 100%));
 
   * {
     box-sizing: border-box;


### PR DESCRIPTION
I want to merge this change because...

This fixes the page shift/jitter that happened when using the navbar. To do this, I calculate the scrollbar width, use a negative margin-right to add it to the body without affecting the sites formatting/styling, and then hide the horizontal overflow that it creates.

Use the https://demo.saleor.io/ for an example of the visual shift that happens when using the navbar. It's hard to see the difference in pictures versus seeing it in action.

<!-- Please mention all relevant issue numbers. -->
#861
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
