### PR TITLE
Fix crash on null price range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Refresh user data if mutation fails - #854 by @dominik-zeglen
 - Fix product list data overfetching - #855 by @dominik-zeglen
 - Add Adyen payment gateway - #845 by @orzechdev
+- Fix crash on null price range - #875 by @orzechdev
 
 ## 2.10.4
 

--- a/src/components/ProductDescription/index.tsx
+++ b/src/components/ProductDescription/index.tsx
@@ -54,8 +54,8 @@ class ProductDescription extends React.Component<
       variant: "",
       variantPricing: null,
       variantPricingRange: {
-        max: props.pricing.priceRange.stop,
-        min: props.pricing.priceRange.start,
+        max: props.pricing.priceRange?.stop,
+        min: props.pricing.priceRange?.start,
       },
       variantStock: null,
     };

--- a/src/components/ProductListItem/index.tsx
+++ b/src/components/ProductListItem/index.tsx
@@ -6,49 +6,16 @@ import * as React from "react";
 import { Thumbnail } from "@components/molecules";
 
 import { TaxedMoney } from "../../@next/components/containers";
-import { BasicProductFields } from "../../views/Product/gqlTypes/BasicProductFields";
-
-export interface Product extends BasicProductFields {
-  category?: {
-    id: string;
-    name: string;
-  };
-  pricing: {
-    priceRange: {
-      start: {
-        gross: {
-          amount: number;
-          currency: string;
-        };
-        net: {
-          amount: number;
-          currency: string;
-        };
-      };
-    };
-    priceRangeUndiscounted: {
-      start: {
-        gross: {
-          amount: number;
-          currency: string;
-        };
-        net: {
-          amount: number;
-          currency: string;
-        };
-      };
-    };
-  };
-}
+import { FeaturedProducts_shop_homepageCollection_products_edges_node } from "../ProductsFeatured/gqlTypes/FeaturedProducts";
 
 interface ProductListItemProps {
-  product: Product;
+  product: FeaturedProducts_shop_homepageCollection_products_edges_node;
 }
 
 const ProductListItem: React.FC<ProductListItemProps> = ({ product }) => {
   const { category } = product;
-  const price = product.pricing.priceRange.start;
-  const priceUndiscounted = product.pricing.priceRangeUndiscounted.start;
+  const price = product.pricing?.priceRange?.start;
+  const priceUndiscounted = product.pricing?.priceRangeUndiscounted?.start;
 
   const getProductPrice = () => {
     if (isEqual(price, priceUndiscounted)) {
@@ -70,7 +37,7 @@ const ProductListItem: React.FC<ProductListItemProps> = ({ product }) => {
         <Thumbnail source={product} />
       </div>
       <h4 className="product-list-item__title">{product.name}</h4>
-      <p className="product-list-item__category">{category.name}</p>
+      <p className="product-list-item__category">{category?.name}</p>
       <p className="product-list-item__price">{getProductPrice()}</p>
     </div>
   );

--- a/src/views/Product/View.tsx
+++ b/src/views/Product/View.tsx
@@ -26,11 +26,11 @@ const canDisplay = (product: ProductDetails_product) =>
 const extractMeta = (product: ProductDetails_product) => ({
   custom: [
     {
-      content: product.pricing.priceRange.start.gross.amount.toString(),
+      content: product.pricing?.priceRange?.start?.gross.amount.toString(),
       property: "product:price:amount",
     },
     {
-      content: product.pricing.priceRange.start.gross.currency,
+      content: product.pricing?.priceRange?.start?.gross.currency,
       property: "product:price:currency",
     },
     {
@@ -38,7 +38,7 @@ const extractMeta = (product: ProductDetails_product) => ({
       property: "product:isAvailable",
     },
     {
-      content: product.category.name,
+      content: product.category?.name,
       property: "product:category",
     },
   ],


### PR DESCRIPTION
I want to merge this change because... it fixes storefront crashes when the price range is null.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

![image](https://user-images.githubusercontent.com/9825562/91171578-01c2ee80-e6db-11ea-82c1-1750ba46ab34.png)
where `index.tsx` was referenced to
![image](https://user-images.githubusercontent.com/9825562/91171593-08516600-e6db-11ea-8348-5ada8960af45.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
