### PR TITLE
Fix test email faker

### DIFF
--- a/cypress/integration/products/buy_a_product.js
+++ b/cypress/integration/products/buy_a_product.js
@@ -4,7 +4,7 @@ import { HEADER_SELECTORS } from "../../elements/main-header/header-selectors";
 import { PRODUCTS_SELECTORS } from "../../elements/products/products-selectors";
 import { CHECKOUT_SELECTORS } from "../../elements/products/checkout-selectors";
 
-const randomWord = faker.random.words(2).replace(" ", "-");
+const randomWord = faker.random.words(2).split(" ").join("-");
 const fakeEmailAdressText = `${randomWord}@example.com`;
 
 const address = {

--- a/cypress/integration/products/buy_a_product.js
+++ b/cypress/integration/products/buy_a_product.js
@@ -4,9 +4,6 @@ import { HEADER_SELECTORS } from "../../elements/main-header/header-selectors";
 import { PRODUCTS_SELECTORS } from "../../elements/products/products-selectors";
 import { CHECKOUT_SELECTORS } from "../../elements/products/checkout-selectors";
 
-const randomWord = faker.random.words(2).split(" ").join("-");
-const fakeEmailAdressText = `${randomWord}@example.com`;
-
 const address = {
   fakeFirstNameText: faker.name.firstName(),
   fakeLastNameInputText: faker.name.lastName(),
@@ -25,6 +22,7 @@ describe("Buy a product", () => {
   it("should buy a shipping product as a logged in user", () => {
     const firstProductName = PRODUCTS_SELECTORS.first_selected_product_name;
 
+    cy.clearLocalStorage();
     cy.loginUserViaRequest()
       .visit("/")
       .clearCart()
@@ -74,6 +72,7 @@ describe("Buy a product", () => {
   });
 
   it("should buy a shipping product as a not logged in user", () => {
+    cy.clearLocalStorage();
     cy.visit("/")
       .clearCart()
       .addItemWithShippingToTheBasket()
@@ -88,7 +87,7 @@ describe("Buy a product", () => {
         return cy.addNewAddress(address);
       })
       .get(CHECKOUT_SELECTORS.SHIPPING_ADDRESS_SELECTORS.emailInput)
-      .type(fakeEmailAdressText)
+      .type("testers@saleor.io")
       .get(
         CHECKOUT_SELECTORS.SHIPPING_ADDRESS_SELECTORS
           .sameAsShippingAddressCheckbox
@@ -118,7 +117,7 @@ describe("Buy a product", () => {
 
   it("should buy a NOT shipping product as a logged in user", () => {
     const firstProductName = PRODUCTS_SELECTORS.first_selected_product_name;
-
+    cy.clearLocalStorage();
     cy.loginUserViaRequest()
       .visit("/")
       .clearCart()
@@ -161,7 +160,7 @@ describe("Buy a product", () => {
   });
 
   xit("should buy a NOT shipping product as a NOT logged in user", () => {
-    // Xited because of the exisiting issue of backend site
+    cy.clearLocalStorage();
     cy.visit("/")
       .clearCart()
       .addItemWithNoShippingToTheBasket()
@@ -176,7 +175,7 @@ describe("Buy a product", () => {
         return cy.addNewAddress(address);
       })
       .get(CHECKOUT_SELECTORS.SHIPPING_ADDRESS_SELECTORS.emailInput)
-      .type(fakeEmailAdressText)
+      .type("testers@saleor.io")
       .get(CHECKOUT_SELECTORS.nextCheckoutStepBtn)
       .click()
       .payment()


### PR DESCRIPTION
I want to merge this change because... it fixes test email faker to fix failing e2e tests.

<!-- Please mention all relevant issue numbers. -->

### Screenshots
It replaces the following email whitespaces:
![image](https://user-images.githubusercontent.com/9825562/91562832-21a61c80-e93e-11ea-8b1a-f61cdda3f4a8.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
