### PR TITLE
Require payment recreate when payment price is wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update collection products query - #879 by @orzechdev
 - Fix checkout refreshing - #865 by @orzechdev
 - Add purchase availability to product details page - #878 by @orzechdev
+- Require payment recreate when payment price is wrong - #892 by @orzechdev
 
 ## 2.10.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5604,8 +5604,9 @@
       }
     },
     "@saleor/sdk": {
-      "version": "github:mirumee/saleor-sdk#93e31be014971bd4d6593831525168b0688451ac",
-      "from": "github:mirumee/saleor-sdk#93e31be",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.1.1.tgz",
+      "integrity": "sha512-XdtJy6PVs1tskqtvNdNwIs868dS+vVglz5klxJqzTb+PqqY3CDTbEOkNjqbkMk/ndN29pKDwCuylP0vmizvdvQ==",
       "requires": {
         "apollo-cache": "^1.3.5",
         "apollo-cache-inmemory": "^1.6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5604,8 +5604,8 @@
       }
     },
     "@saleor/sdk": {
-      "version": "github:mirumee/saleor-sdk#5b9f96be7948c3613b3a3b31303f55baf2385c92",
-      "from": "github:mirumee/saleor-sdk#5b9f96b",
+      "version": "github:mirumee/saleor-sdk#93e31be014971bd4d6593831525168b0688451ac",
+      "from": "github:mirumee/saleor-sdk#93e31be",
       "requires": {
         "apollo-cache": "^1.3.5",
         "apollo-cache-inmemory": "^1.6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5604,9 +5604,8 @@
       }
     },
     "@saleor/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ZLVqPx1K9me7fslcxrGnGJ4Gq3ydmA+Yk/kK75bdNs+J8xZwZAxLhOl3lS1C/KGu7InNQvn7zQbTULwu7Oqn/Q==",
+      "version": "github:mirumee/saleor-sdk#5b9f96be7948c3613b3a3b31303f55baf2385c92",
+      "from": "github:mirumee/saleor-sdk#5b9f96b",
       "requires": {
         "apollo-cache": "^1.3.5",
         "apollo-cache-inmemory": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@lhci/cli": "^0.4.1",
-    "@saleor/sdk": "github:mirumee/saleor-sdk#5b9f96b",
+    "@saleor/sdk": "github:mirumee/saleor-sdk#93e31be",
     "@sentry/apm": "^5.15.5",
     "@sentry/browser": "^5.15.5",
     "@stripe/react-stripe-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@lhci/cli": "^0.4.1",
-    "@saleor/sdk": "github:mirumee/saleor-sdk#93e31be",
+    "@saleor/sdk": "^0.1.1",
     "@sentry/apm": "^5.15.5",
     "@sentry/browser": "^5.15.5",
     "@stripe/react-stripe-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@lhci/cli": "^0.4.1",
-    "@saleor/sdk": "^0.1.0",
+    "@saleor/sdk": "github:mirumee/saleor-sdk#5b9f96b",
     "@sentry/apm": "^5.15.5",
     "@sentry/browser": "^5.15.5",
     "@stripe/react-stripe-js": "^1.1.2",

--- a/src/@next/hooks/useCheckoutStepState.ts
+++ b/src/@next/hooks/useCheckoutStepState.ts
@@ -1,32 +1,47 @@
 import { useEffect, useState } from "react";
 
-import { IItems } from "@saleor/sdk/lib/api/Cart/types";
+import { IItems, ITotalPrice } from "@saleor/sdk/lib/api/Cart/types";
 import { ICheckout, IPayment } from "@saleor/sdk/lib/api/Checkout/types";
 import { CheckoutStep } from "@temp/core/config";
+
+interface StepState {
+  recommendedStep: CheckoutStep;
+  maxPossibleStep: CheckoutStep;
+}
 
 export const useCheckoutStepState = (
   items?: IItems,
   checkout?: ICheckout,
-  payment?: IPayment
-): CheckoutStep => {
-  const isShippingRequiredForProducts =
-    items &&
-    items.some(
-      ({ variant }) => variant.product?.productType.isShippingRequired
+  payment?: IPayment,
+  totalPrice?: ITotalPrice
+): StepState => {
+  const checkIfCheckoutPriceEqualPaymentPrice = () => {
+    return (
+      totalPrice?.gross.amount === payment?.total?.amount &&
+      totalPrice?.gross.currency === payment?.total?.currency
     );
+  };
 
-  const getStep = () => {
+  const getMaxPossibleStep = () => {
     if (!checkout?.id && items) {
       // we are creating checkout during address set up
       return CheckoutStep.Address;
     }
+
+    const isCheckoutPriceEqualPaymentPrice = checkIfCheckoutPriceEqualPaymentPrice();
+    const isShippingRequiredForProducts =
+      items &&
+      items.some(
+        ({ variant }) => variant.product?.productType.isShippingRequired
+      );
 
     const isShippingAddressSet =
       !isShippingRequiredForProducts || !!checkout?.shippingAddress;
     const isBillingAddressSet = !!checkout?.billingAddress;
     const isShippingMethodSet =
       !isShippingRequiredForProducts || !!checkout?.shippingMethod;
-    const isPaymentMethodSet = !!payment?.id;
+    const isPaymentMethodSet =
+      !!payment?.id && isCheckoutPriceEqualPaymentPrice;
 
     if (!isShippingAddressSet || !isBillingAddressSet) {
       return CheckoutStep.Address;
@@ -40,14 +55,33 @@ export const useCheckoutStepState = (
     return CheckoutStep.Review;
   };
 
-  const [step, setStep] = useState(getStep());
+  const getRecommendedStep = (newMaxPossibleStep: CheckoutStep) => {
+    const isCheckoutPriceEqualPaymentPrice = checkIfCheckoutPriceEqualPaymentPrice();
+
+    if (
+      newMaxPossibleStep > CheckoutStep.Shipping &&
+      !isCheckoutPriceEqualPaymentPrice
+    ) {
+      return CheckoutStep.Shipping;
+    }
+    return newMaxPossibleStep;
+  };
+
+  const [maxPossibleStep, setMaxPossibleStep] = useState(getMaxPossibleStep());
+  const [recommendedStep, setRecommendedStep] = useState(
+    getRecommendedStep(maxPossibleStep)
+  );
 
   useEffect(() => {
-    const newStep = getStep();
-    if (step !== newStep) {
-      setStep(newStep);
+    const newMaxPossibleStep = getMaxPossibleStep();
+    const newRecommendedStep = getRecommendedStep(newMaxPossibleStep);
+    if (maxPossibleStep !== newMaxPossibleStep) {
+      setMaxPossibleStep(newMaxPossibleStep);
     }
-  }, [checkout, items, payment]);
+    if (recommendedStep !== newRecommendedStep) {
+      setRecommendedStep(newRecommendedStep);
+    }
+  }, [checkout, items, payment, totalPrice]);
 
-  return step;
+  return { recommendedStep, maxPossibleStep };
 };

--- a/src/@next/hooks/useCheckoutStepState.ts
+++ b/src/@next/hooks/useCheckoutStepState.ts
@@ -3,10 +3,8 @@ import { useEffect, useState } from "react";
 import { IItems, ITotalPrice } from "@saleor/sdk/lib/api/Cart/types";
 import { ICheckout, IPayment } from "@saleor/sdk/lib/api/Checkout/types";
 import { CheckoutStep } from "@temp/core/config";
-import {
-  checkIfShippingRequiredForProducts,
-  checkIfCheckoutPriceEqualPaymentPrice,
-} from "@utils/core";
+import { checkIfShippingRequiredForProducts } from "@utils/core";
+import { isPriceEqual } from "@utils/money";
 
 interface StepState {
   recommendedStep: CheckoutStep;
@@ -22,10 +20,10 @@ export const useCheckoutStepState = (
   const isShippingRequiredForProducts = checkIfShippingRequiredForProducts(
     items
   );
-  const isCheckoutPriceEqualPaymentPrice = checkIfCheckoutPriceEqualPaymentPrice(
-    payment,
-    totalPrice
-  );
+  const isCheckoutPriceEqualPaymentPrice =
+    payment?.total &&
+    totalPrice?.gross &&
+    isPriceEqual(payment.total, totalPrice.gross);
 
   const getMaxPossibleStep = () => {
     if (!checkout?.id && items) {

--- a/src/@next/pages/CheckoutPage/CheckoutPage.tsx
+++ b/src/@next/pages/CheckoutPage/CheckoutPage.tsx
@@ -241,6 +241,7 @@ const CheckoutPage: React.FC<IProps> = ({}: IProps) => {
         items={items}
         checkout={checkout}
         payment={payment}
+        totalPrice={totalPrice}
         renderAddress={props => (
           <CheckoutAddressSubpage
             ref={checkoutAddressSubpageRef}

--- a/src/@next/pages/CheckoutPage/CheckoutRouter.tsx
+++ b/src/@next/pages/CheckoutPage/CheckoutRouter.tsx
@@ -11,6 +11,7 @@ import { useCheckoutStepFromPath, useCheckoutStepState } from "@hooks";
 import { IItems, ITotalPrice } from "@saleor/sdk/lib/api/Cart/types";
 import { ICheckout, IPayment } from "@saleor/sdk/lib/api/Checkout/types";
 import { CHECKOUT_STEPS } from "@temp/core/config";
+import { checkIfShippingRequiredForProducts } from "@utils/core";
 
 interface IRouterProps {
   items?: IItems;
@@ -42,13 +43,18 @@ const CheckoutRouter: React.FC<IRouterProps> = ({
   );
   const stepFromPath = useCheckoutStepFromPath(pathname);
 
+  const isShippingRequiredForProducts = checkIfShippingRequiredForProducts(
+    items
+  );
+
   const getStepLink = () =>
     CHECKOUT_STEPS.find(stepObj => stepObj.step === recommendedStep)?.link ||
     CHECKOUT_STEPS[0].link;
 
   if (
-    pathname !== CHECKOUT_STEPS[4].link &&
-    (!stepFromPath || (stepFromPath && maxPossibleStep < stepFromPath))
+    (pathname !== CHECKOUT_STEPS[4].link &&
+      (!stepFromPath || (stepFromPath && maxPossibleStep < stepFromPath))) ||
+    (pathname === CHECKOUT_STEPS[1].link && !isShippingRequiredForProducts)
   ) {
     return <Redirect to={getStepLink()} />;
   }

--- a/src/@next/pages/CheckoutPage/CheckoutRouter.tsx
+++ b/src/@next/pages/CheckoutPage/CheckoutRouter.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-router-dom";
 
 import { useCheckoutStepFromPath, useCheckoutStepState } from "@hooks";
-import { IItems } from "@saleor/sdk/lib/api/Cart/types";
+import { IItems, ITotalPrice } from "@saleor/sdk/lib/api/Cart/types";
 import { ICheckout, IPayment } from "@saleor/sdk/lib/api/Checkout/types";
 import { CHECKOUT_STEPS } from "@temp/core/config";
 
@@ -16,6 +16,7 @@ interface IRouterProps {
   items?: IItems;
   checkout?: ICheckout;
   payment?: IPayment;
+  totalPrice?: ITotalPrice;
   renderAddress: (props: RouteComponentProps<any>) => React.ReactNode;
   renderShipping: (props: RouteComponentProps<any>) => React.ReactNode;
   renderPayment: (props: RouteComponentProps<any>) => React.ReactNode;
@@ -26,22 +27,28 @@ const CheckoutRouter: React.FC<IRouterProps> = ({
   items,
   checkout,
   payment,
+  totalPrice,
   renderAddress,
   renderShipping,
   renderPayment,
   renderReview,
 }: IRouterProps) => {
   const { pathname } = useLocation();
-  const step = useCheckoutStepState(items, checkout, payment);
+  const { recommendedStep, maxPossibleStep } = useCheckoutStepState(
+    items,
+    checkout,
+    payment,
+    totalPrice
+  );
   const stepFromPath = useCheckoutStepFromPath(pathname);
 
   const getStepLink = () =>
-    CHECKOUT_STEPS.find(stepObj => stepObj.step === step)?.link ||
+    CHECKOUT_STEPS.find(stepObj => stepObj.step === recommendedStep)?.link ||
     CHECKOUT_STEPS[0].link;
 
   if (
     pathname !== CHECKOUT_STEPS[4].link &&
-    (!stepFromPath || (stepFromPath && step < stepFromPath))
+    (!stepFromPath || (stepFromPath && maxPossibleStep < stepFromPath))
   ) {
     return <Redirect to={getStepLink()} />;
   }

--- a/src/@next/types/ITaxedMoney.ts
+++ b/src/@next/types/ITaxedMoney.ts
@@ -1,10 +1,9 @@
+export interface IMoney {
+  amount: number;
+  currency: string;
+}
+
 export interface ITaxedMoney {
-  net: {
-    amount: number;
-    currency: string;
-  };
-  gross: {
-    amount: number;
-    currency: string;
-  };
+  net: IMoney;
+  gross: IMoney;
 }

--- a/src/@next/utils/core.ts
+++ b/src/@next/utils/core.ts
@@ -2,6 +2,9 @@
 // @ts-ignore
 import { Base64 } from "js-base64";
 
+import { IItems, ITotalPrice } from "@saleor/sdk/lib/api/Cart/types";
+import { IPayment } from "@saleor/sdk/lib/api/Checkout/types";
+
 export const slugify = (text: string | number): string =>
   text
     .toString()
@@ -36,3 +39,13 @@ export const generatePageUrl = (slug: string) => `/page/${slug}/`;
 
 export const generateGuestOrderDetailsUrl = (token: string) =>
   `/order-history/${token}/`;
+
+export const checkIfShippingRequiredForProducts = (items?: IItems) =>
+  items?.some(({ variant }) => variant.product?.productType.isShippingRequired);
+
+export const checkIfCheckoutPriceEqualPaymentPrice = (
+  payment?: IPayment,
+  totalPrice?: ITotalPrice
+) =>
+  totalPrice?.gross.amount === payment?.total?.amount &&
+  totalPrice?.gross.currency === payment?.total?.currency;

--- a/src/@next/utils/core.ts
+++ b/src/@next/utils/core.ts
@@ -2,8 +2,7 @@
 // @ts-ignore
 import { Base64 } from "js-base64";
 
-import { IItems, ITotalPrice } from "@saleor/sdk/lib/api/Cart/types";
-import { IPayment } from "@saleor/sdk/lib/api/Checkout/types";
+import { IItems } from "@saleor/sdk/lib/api/Cart/types";
 
 export const slugify = (text: string | number): string =>
   text
@@ -42,10 +41,3 @@ export const generateGuestOrderDetailsUrl = (token: string) =>
 
 export const checkIfShippingRequiredForProducts = (items?: IItems) =>
   items?.some(({ variant }) => variant.product?.productType.isShippingRequired);
-
-export const checkIfCheckoutPriceEqualPaymentPrice = (
-  payment?: IPayment,
-  totalPrice?: ITotalPrice
-) =>
-  totalPrice?.gross.amount === payment?.total?.amount &&
-  totalPrice?.gross.currency === payment?.total?.currency;

--- a/src/@next/utils/money.test.ts
+++ b/src/@next/utils/money.test.ts
@@ -1,0 +1,46 @@
+import { IMoney } from "@types";
+
+import { isPriceEqual } from "./money";
+
+const firstPrice: IMoney = {
+  amount: 100,
+  currency: "USD",
+};
+
+describe("Comparing two prices", () => {
+  it("Returns true if amount and currency is same", () => {
+    const secondPrice: IMoney = {
+      amount: 100,
+      currency: "USD",
+    };
+
+    expect(isPriceEqual(firstPrice, secondPrice)).toBeTruthy();
+  });
+
+  it("Returns false if amount is same and currency is not", () => {
+    const secondPrice: IMoney = {
+      amount: 100,
+      currency: "PLN",
+    };
+
+    expect(isPriceEqual(firstPrice, secondPrice)).toBeFalsy();
+  });
+
+  it("Returns false if currency is same and amount is not", () => {
+    const secondPrice: IMoney = {
+      amount: 200,
+      currency: "USD",
+    };
+
+    expect(isPriceEqual(firstPrice, secondPrice)).toBeFalsy();
+  });
+
+  it("Returns false if amount and currency is not same", () => {
+    const secondPrice: IMoney = {
+      amount: 200,
+      currency: "PLN",
+    };
+
+    expect(isPriceEqual(firstPrice, secondPrice)).toBeFalsy();
+  });
+});

--- a/src/@next/utils/money.ts
+++ b/src/@next/utils/money.ts
@@ -1,0 +1,4 @@
+import { IMoney } from "@types";
+
+export const isPriceEqual = (first: IMoney, second: IMoney) =>
+  first.amount === second.amount && first.currency === second.currency;


### PR DESCRIPTION
I want to merge this change because... it
- redirects the user to shipping step if payment amount is not equal to checkout total price (e.g. item was added to the cart) and thanks to it payment may be recreated with proper payment amount
- still preserves the possibility for user to go to payment step when shipping was set already
- fixes the case when user removes all items requiring shipping, leaving only digital product, when active path was `/checkout/shipping` and user was not redirected to other possible step
- fixes the case when user removes all items requiring shipping, leaving only digital product and shipping method was still wrongly set, while it shouldn't exist anymore and total price should be updated
- shipping method is now updated after adding/removing item to cart, and together with updated shipping methods introduced in https://github.com/mirumee/saleor-storefront/pull/865, it is going to fix https://github.com/mirumee/saleor-storefront/issues/885.

⚠️ Before merge SDK dependency must be updated with changes introduced in https://github.com/mirumee/saleor-sdk/pull/33

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
