### PR TITLE
use defaultChannelSlug in queries and mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Add EditorJS renderer - #947 by @krzysztofwolski
 - New cart sidebar - #907 by @orzechdev
+- Support for multichannel - #937 by @AlicjaSzu
 
 ## 2.11.0
 
@@ -42,7 +43,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Support for static URL - #721 by @marianoeramirez and @dominik-zeglen
 - Fix search crashing when displaying item with no category - #928 by @mmarkusik
 - Fix generating site map - #915 by @rboixaderg
-- Use defaultChannelSlug in queries and mutations - #937 by @AlicjaSzu
 
 ## 2.10.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Support for static URL - #721 by @marianoeramirez and @dominik-zeglen
 - Fix search crashing when displaying item with no category - #928 by @mmarkusik
 - Fix generating site map - #915 by @rboixaderg
-
+- Use defaultChannelSlug in queries and mutations - #937 by @AlicjaSzu
 
 ## 2.10.4
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ npm run generate
     - Check to see that "Less secure app access" is turned ON. Under "Manage your Google Account" > Go to the security tab. By default, the setting is off for security reasons.
     - If using 2FA make sure to set an [app password](https://support.google.com/accounts/answer/185833?p=InvalidSecondFactor&visit_id=637355441414497566-1310044707&rd=1) and use that in place of your normal login password.
 
+### Multichannel
+
+- **Set [DEFAULT_CHANNEL_SLUG] environment variable.**
+
 ## License
 
 This project is licensed under the BSD-3-Clause License - see the [LICENSE](https://github.com/mirumee/saleor-storefront/blob/master/LICENSE) file for details

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ npm run generate
 
 ### Multichannel
 
-- **Set [DEFAULT_CHANNEL_SLUG] environment variable.**
+- **Set [SALEOR_CHANNEL_SLUG] environment variable.** - Default value: `default-channel`.
 
 ## License
 

--- a/config/webpack/config.base.js
+++ b/config/webpack/config.base.js
@@ -118,6 +118,7 @@ module.exports = ({ sourceDir, distDir }) => ({
     }),
     new webpack.EnvironmentPlugin({
       API_URI: "http://localhost:8000/graphql/",
+      DEFAULT_CHANNEL_SLUG: "",
       DEMO_MODE: false,
       GTM_ID: undefined,
       SENTRY_APM: "0",

--- a/config/webpack/config.base.js
+++ b/config/webpack/config.base.js
@@ -118,7 +118,7 @@ module.exports = ({ sourceDir, distDir }) => ({
     }),
     new webpack.EnvironmentPlugin({
       API_URI: "http://localhost:8000/graphql/",
-      DEFAULT_CHANNEL_SLUG: "default-channel",
+      SALEOR_CHANNEL_SLUG: "default-channel",
       DEMO_MODE: false,
       GTM_ID: undefined,
       SENTRY_APM: "0",

--- a/config/webpack/config.base.js
+++ b/config/webpack/config.base.js
@@ -118,7 +118,7 @@ module.exports = ({ sourceDir, distDir }) => ({
     }),
     new webpack.EnvironmentPlugin({
       API_URI: "http://localhost:8000/graphql/",
-      DEFAULT_CHANNEL_SLUG: "",
+      DEFAULT_CHANNEL_SLUG: "default-channel",
       DEMO_MODE: false,
       GTM_ID: undefined,
       SENTRY_APM: "0",

--- a/gqlTypes/globalTypes.ts
+++ b/gqlTypes/globalTypes.ts
@@ -268,12 +268,14 @@ export enum OrderDirection {
 }
 
 export enum ProductOrderField {
+  COLLECTION = "COLLECTION",
   DATE = "DATE",
   MINIMAL_PRICE = "MINIMAL_PRICE",
   NAME = "NAME",
   PRICE = "PRICE",
   PUBLICATION_DATE = "PUBLICATION_DATE",
   PUBLISHED = "PUBLISHED",
+  RATING = "RATING",
   TYPE = "TYPE",
 }
 

--- a/gqlTypes/globalTypes.ts
+++ b/gqlTypes/globalTypes.ts
@@ -272,6 +272,7 @@ export enum ProductOrderField {
   MINIMAL_PRICE = "MINIMAL_PRICE",
   NAME = "NAME",
   PRICE = "PRICE",
+  PUBLICATION_DATE = "PUBLICATION_DATE",
   PUBLISHED = "PUBLISHED",
   TYPE = "TYPE",
 }
@@ -284,6 +285,7 @@ export interface AttributeInput {
 
 export interface ProductOrder {
   direction: OrderDirection;
+  channel?: string | null;
   attributeId?: string | null;
   field?: ProductOrderField | null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6119,9 +6119,9 @@
       }
     },
     "@saleor/sdk": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.1.5.tgz",
-      "integrity": "sha512-2LwdgF77CbZTR19aUkxwXR6WCjqREB33cSi+1SVRWEE9Yn5E1q6GQH7Cn1lUxdkfuQc1pSUJ2N6ifMfNGA0pmw==",
+      "version": "0.3.0-0",
+      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.3.0-0.tgz",
+      "integrity": "sha512-p0jlZFYcmv8Gexfl3WNq7FSMGo6gcxc+LuNYnVNYnXDyBEJE9cQ31/id+NaoJ5l9fSrLRM/LyJF3ICgU0eFT0Q==",
       "requires": {
         "apollo-cache": "^1.3.5",
         "apollo-cache-inmemory": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@editorjs/list": "^1.6.0",
     "@editorjs/quote": "^2.4.0",
     "@lhci/cli": "^0.4.1",
-    "@saleor/sdk": "^0.1.5",
+    "@saleor/sdk": "^0.3.0-0",
     "@sentry/apm": "^5.15.5",
     "@sentry/browser": "^5.15.5",
     "@stripe/react-stripe-js": "^1.1.2",

--- a/src/components/Footer/Nav.tsx
+++ b/src/components/Footer/Nav.tsx
@@ -1,4 +1,4 @@
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import * as React from "react";
 
 import { NavLink } from "..";
@@ -13,7 +13,7 @@ class Nav extends React.PureComponent {
         <div className="container">
           <TypedSecondaryMenuQuery
             variables={{
-              channel: defaultChannelSlug,
+              channel: channelSlug,
               slug: "footer",
             }}
           >

--- a/src/components/Footer/Nav.tsx
+++ b/src/components/Footer/Nav.tsx
@@ -1,3 +1,4 @@
+import { defaultChannelSlug } from "@temp/constants";
 import * as React from "react";
 
 import { NavLink } from "..";
@@ -10,9 +11,14 @@ class Nav extends React.PureComponent {
     return (
       <footer className="footer-nav">
         <div className="container">
-          <TypedSecondaryMenuQuery>
+          <TypedSecondaryMenuQuery
+            variables={{
+              channel: defaultChannelSlug,
+              slug: "footer",
+            }}
+          >
             {({ data }) => {
-              return data.shop.navigation.secondary.items.map(item => (
+              return data.menu.items.map(item => (
                 <div className="footer-nav__section" key={item.id}>
                   <h4 className="footer-nav__section-header">
                     <NavLink item={item} />

--- a/src/components/Footer/gqlTypes/SecondaryMenu.ts
+++ b/src/components/Footer/gqlTypes/SecondaryMenu.ts
@@ -6,7 +6,7 @@
 // GraphQL query operation: SecondaryMenu
 // ====================================================
 
-export interface SecondaryMenu_shop_navigation_secondary_items_category {
+export interface SecondaryMenu_menu_items_category {
   __typename: "Category";
   /**
    * The ID of the object.
@@ -15,7 +15,7 @@ export interface SecondaryMenu_shop_navigation_secondary_items_category {
   name: string;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary_items_collection {
+export interface SecondaryMenu_menu_items_collection {
   __typename: "Collection";
   /**
    * The ID of the object.
@@ -24,12 +24,12 @@ export interface SecondaryMenu_shop_navigation_secondary_items_collection {
   name: string;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary_items_page {
+export interface SecondaryMenu_menu_items_page {
   __typename: "Page";
   slug: string;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary_items_children_category {
+export interface SecondaryMenu_menu_items_children_category {
   __typename: "Category";
   /**
    * The ID of the object.
@@ -38,7 +38,7 @@ export interface SecondaryMenu_shop_navigation_secondary_items_children_category
   name: string;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary_items_children_collection {
+export interface SecondaryMenu_menu_items_children_collection {
   __typename: "Collection";
   /**
    * The ID of the object.
@@ -47,68 +47,57 @@ export interface SecondaryMenu_shop_navigation_secondary_items_children_collecti
   name: string;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary_items_children_page {
+export interface SecondaryMenu_menu_items_children_page {
   __typename: "Page";
   slug: string;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary_items_children {
+export interface SecondaryMenu_menu_items_children {
   __typename: "MenuItem";
   /**
    * The ID of the object.
    */
   id: string;
   name: string;
-  category: SecondaryMenu_shop_navigation_secondary_items_children_category | null;
+  category: SecondaryMenu_menu_items_children_category | null;
   /**
    * URL to the menu item.
    */
   url: string | null;
-  collection: SecondaryMenu_shop_navigation_secondary_items_children_collection | null;
-  page: SecondaryMenu_shop_navigation_secondary_items_children_page | null;
+  collection: SecondaryMenu_menu_items_children_collection | null;
+  page: SecondaryMenu_menu_items_children_page | null;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary_items {
+export interface SecondaryMenu_menu_items {
   __typename: "MenuItem";
   /**
    * The ID of the object.
    */
   id: string;
   name: string;
-  category: SecondaryMenu_shop_navigation_secondary_items_category | null;
+  category: SecondaryMenu_menu_items_category | null;
   /**
    * URL to the menu item.
    */
   url: string | null;
-  collection: SecondaryMenu_shop_navigation_secondary_items_collection | null;
-  page: SecondaryMenu_shop_navigation_secondary_items_page | null;
-  children: (SecondaryMenu_shop_navigation_secondary_items_children | null)[] | null;
+  collection: SecondaryMenu_menu_items_collection | null;
+  page: SecondaryMenu_menu_items_page | null;
+  children: (SecondaryMenu_menu_items_children | null)[] | null;
 }
 
-export interface SecondaryMenu_shop_navigation_secondary {
+export interface SecondaryMenu_menu {
   __typename: "Menu";
-  items: (SecondaryMenu_shop_navigation_secondary_items | null)[] | null;
-}
-
-export interface SecondaryMenu_shop_navigation {
-  __typename: "Navigation";
-  /**
-   * Secondary navigation bar.
-   */
-  secondary: SecondaryMenu_shop_navigation_secondary | null;
-}
-
-export interface SecondaryMenu_shop {
-  __typename: "Shop";
-  /**
-   * Shop's navigation.
-   */
-  navigation: SecondaryMenu_shop_navigation | null;
+  items: (SecondaryMenu_menu_items | null)[] | null;
 }
 
 export interface SecondaryMenu {
   /**
-   * Return information about the shop.
+   * Look up a navigation menu by ID or name.
    */
-  shop: SecondaryMenu_shop;
+  menu: SecondaryMenu_menu | null;
+}
+
+export interface SecondaryMenuVariables {
+  channel: string;
+  slug: string;
 }

--- a/src/components/Footer/queries.ts
+++ b/src/components/Footer/queries.ts
@@ -21,16 +21,12 @@ const secondaryMenu = gql`
     }
   }
 
-  query SecondaryMenu {
-    shop {
-      navigation {
-        secondary {
-          items {
-            ...SecondaryMenuSubItem
-            children {
-              ...SecondaryMenuSubItem
-            }
-          }
+  query SecondaryMenu($channel: String!, $slug: String!) {
+    menu(channel: $channel, slug: $slug) {
+      items {
+        ...SecondaryMenuSubItem
+        children {
+          ...SecondaryMenuSubItem
         }
       }
     }

--- a/src/components/MainMenu/MainMenu.tsx
+++ b/src/components/MainMenu/MainMenu.tsx
@@ -9,6 +9,7 @@ import ReactSVG from "react-svg";
 
 import { DemoBanner } from "@components/atoms";
 import classNames from "classnames";
+import { defaultChannelSlug } from "@temp/constants";
 import {
   MenuDropdown,
   Offline,
@@ -84,9 +85,16 @@ const MainMenu: React.FC<MainMenuProps> = ({ demoMode }) => {
       {demoMode && <DemoBanner />}
       <nav className="main-menu" id="header">
         <div className="main-menu__left">
-          <TypedMainMenuQuery renderOnError displayLoader={false}>
+          <TypedMainMenuQuery
+            renderOnError
+            displayLoader={false}
+            variables={{
+              channel: defaultChannelSlug,
+              slug: "navbar",
+            }}
+          >
             {({ data }) => {
-              const items = maybe(() => data.shop.navigation.main.items, []);
+              const items = maybe(() => data.menu.items, []);
 
               return (
                 <ul>

--- a/src/components/MainMenu/MainMenu.tsx
+++ b/src/components/MainMenu/MainMenu.tsx
@@ -9,7 +9,7 @@ import ReactSVG from "react-svg";
 
 import { DemoBanner } from "@components/atoms";
 import classNames from "classnames";
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import {
   MenuDropdown,
   Offline,
@@ -89,7 +89,7 @@ const MainMenu: React.FC<MainMenuProps> = ({ demoMode }) => {
             renderOnError
             displayLoader={false}
             variables={{
-              channel: defaultChannelSlug,
+              channel: channelSlug,
               slug: "navbar",
             }}
           >

--- a/src/components/MainMenu/NavDropdown.tsx
+++ b/src/components/MainMenu/NavDropdown.tsx
@@ -4,13 +4,13 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { NavLink, OverlayContextInterface } from "..";
-import { MainMenu_shop_navigation_main_items } from "./gqlTypes/MainMenu";
+import { MainMenu_menu_items } from "./gqlTypes/MainMenu";
 import NavItem from "./NavItem";
 
 import "./scss/index.scss";
 
 class NavDropdown extends React.PureComponent<
-  MainMenu_shop_navigation_main_items & {
+  MainMenu_menu_items & {
     overlay: OverlayContextInterface;
     showDropdown: boolean;
     onShowDropdown: () => void;

--- a/src/components/MainMenu/gqlTypes/MainMenu.ts
+++ b/src/components/MainMenu/gqlTypes/MainMenu.ts
@@ -6,7 +6,7 @@
 // GraphQL query operation: MainMenu
 // ====================================================
 
-export interface MainMenu_shop_navigation_main_items_category {
+export interface MainMenu_menu_items_category {
   __typename: "Category";
   /**
    * The ID of the object.
@@ -15,7 +15,7 @@ export interface MainMenu_shop_navigation_main_items_category {
   name: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_collection {
+export interface MainMenu_menu_items_collection {
   __typename: "Collection";
   /**
    * The ID of the object.
@@ -24,12 +24,12 @@ export interface MainMenu_shop_navigation_main_items_collection {
   name: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_page {
+export interface MainMenu_menu_items_page {
   __typename: "Page";
   slug: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_parent {
+export interface MainMenu_menu_items_parent {
   __typename: "MenuItem";
   /**
    * The ID of the object.
@@ -37,7 +37,7 @@ export interface MainMenu_shop_navigation_main_items_parent {
   id: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_category {
+export interface MainMenu_menu_items_children_category {
   __typename: "Category";
   /**
    * The ID of the object.
@@ -46,7 +46,7 @@ export interface MainMenu_shop_navigation_main_items_children_category {
   name: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_collection {
+export interface MainMenu_menu_items_children_collection {
   __typename: "Collection";
   /**
    * The ID of the object.
@@ -55,12 +55,12 @@ export interface MainMenu_shop_navigation_main_items_children_collection {
   name: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_page {
+export interface MainMenu_menu_items_children_page {
   __typename: "Page";
   slug: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_parent {
+export interface MainMenu_menu_items_children_parent {
   __typename: "MenuItem";
   /**
    * The ID of the object.
@@ -68,7 +68,7 @@ export interface MainMenu_shop_navigation_main_items_children_parent {
   id: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_children_category {
+export interface MainMenu_menu_items_children_children_category {
   __typename: "Category";
   /**
    * The ID of the object.
@@ -77,7 +77,7 @@ export interface MainMenu_shop_navigation_main_items_children_children_category 
   name: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_children_collection {
+export interface MainMenu_menu_items_children_children_collection {
   __typename: "Collection";
   /**
    * The ID of the object.
@@ -86,12 +86,12 @@ export interface MainMenu_shop_navigation_main_items_children_children_collectio
   name: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_children_page {
+export interface MainMenu_menu_items_children_children_page {
   __typename: "Page";
   slug: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_children_parent {
+export interface MainMenu_menu_items_children_children_parent {
   __typename: "MenuItem";
   /**
    * The ID of the object.
@@ -99,87 +99,76 @@ export interface MainMenu_shop_navigation_main_items_children_children_parent {
   id: string;
 }
 
-export interface MainMenu_shop_navigation_main_items_children_children {
-  __typename: "MenuItem";
-  /**
-   * The ID of the object.
-   */
-  id: string;
-  name: string;
-  category: MainMenu_shop_navigation_main_items_children_children_category | null;
-  /**
-   * URL to the menu item.
-   */
-  url: string | null;
-  collection: MainMenu_shop_navigation_main_items_children_children_collection | null;
-  page: MainMenu_shop_navigation_main_items_children_children_page | null;
-  parent: MainMenu_shop_navigation_main_items_children_children_parent | null;
-}
-
-export interface MainMenu_shop_navigation_main_items_children {
+export interface MainMenu_menu_items_children_children {
   __typename: "MenuItem";
   /**
    * The ID of the object.
    */
   id: string;
   name: string;
-  category: MainMenu_shop_navigation_main_items_children_category | null;
+  category: MainMenu_menu_items_children_children_category | null;
   /**
    * URL to the menu item.
    */
   url: string | null;
-  collection: MainMenu_shop_navigation_main_items_children_collection | null;
-  page: MainMenu_shop_navigation_main_items_children_page | null;
-  parent: MainMenu_shop_navigation_main_items_children_parent | null;
-  children: (MainMenu_shop_navigation_main_items_children_children | null)[] | null;
+  collection: MainMenu_menu_items_children_children_collection | null;
+  page: MainMenu_menu_items_children_children_page | null;
+  parent: MainMenu_menu_items_children_children_parent | null;
 }
 
-export interface MainMenu_shop_navigation_main_items {
+export interface MainMenu_menu_items_children {
   __typename: "MenuItem";
   /**
    * The ID of the object.
    */
   id: string;
   name: string;
-  category: MainMenu_shop_navigation_main_items_category | null;
+  category: MainMenu_menu_items_children_category | null;
   /**
    * URL to the menu item.
    */
   url: string | null;
-  collection: MainMenu_shop_navigation_main_items_collection | null;
-  page: MainMenu_shop_navigation_main_items_page | null;
-  parent: MainMenu_shop_navigation_main_items_parent | null;
-  children: (MainMenu_shop_navigation_main_items_children | null)[] | null;
+  collection: MainMenu_menu_items_children_collection | null;
+  page: MainMenu_menu_items_children_page | null;
+  parent: MainMenu_menu_items_children_parent | null;
+  children: (MainMenu_menu_items_children_children | null)[] | null;
 }
 
-export interface MainMenu_shop_navigation_main {
+export interface MainMenu_menu_items {
+  __typename: "MenuItem";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string;
+  category: MainMenu_menu_items_category | null;
+  /**
+   * URL to the menu item.
+   */
+  url: string | null;
+  collection: MainMenu_menu_items_collection | null;
+  page: MainMenu_menu_items_page | null;
+  parent: MainMenu_menu_items_parent | null;
+  children: (MainMenu_menu_items_children | null)[] | null;
+}
+
+export interface MainMenu_menu {
   __typename: "Menu";
   /**
    * The ID of the object.
    */
   id: string;
-  items: (MainMenu_shop_navigation_main_items | null)[] | null;
-}
-
-export interface MainMenu_shop_navigation {
-  __typename: "Navigation";
-  /**
-   * Main navigation bar.
-   */
-  main: MainMenu_shop_navigation_main | null;
-}
-
-export interface MainMenu_shop {
-  __typename: "Shop";
-  /**
-   * Shop's navigation.
-   */
-  navigation: MainMenu_shop_navigation | null;
+  items: (MainMenu_menu_items | null)[] | null;
 }
 
 export interface MainMenu {
   /**
-   * Return information about the shop.
+   * Look up a navigation menu by ID or name.
    */
-  shop: MainMenu_shop;
+  menu: MainMenu_menu | null;
+}
+
+export interface MainMenuVariables {
+  channel: string;
+  slug: string;
 }

--- a/src/components/MainMenu/queries.ts
+++ b/src/components/MainMenu/queries.ts
@@ -23,19 +23,15 @@ export const mainMenu = gql`
     }
   }
 
-  query MainMenu {
-    shop {
-      navigation {
-        main {
-          id
-          items {
+  query MainMenu($channel: String!, $slug: String!) {
+    menu(channel: $channel, slug: $slug) {
+      id
+      items {
+        ...MainMenuSubItem
+        children {
+          ...MainMenuSubItem
+          children {
             ...MainMenuSubItem
-            children {
-              ...MainMenuSubItem
-              children {
-                ...MainMenuSubItem
-              }
-            }
           }
         }
       }

--- a/src/components/NavLink/index.tsx
+++ b/src/components/NavLink/index.tsx
@@ -7,18 +7,18 @@ import {
   generatePageUrl,
 } from "../../core/utils";
 import {
-  SecondaryMenu_shop_navigation_secondary_items,
-  SecondaryMenu_shop_navigation_secondary_items_children,
+  SecondaryMenu_menu_items,
+  SecondaryMenu_menu_items_children,
 } from "../Footer/gqlTypes/SecondaryMenu";
-import { MainMenu_shop_navigation_main_items } from "../MainMenu/gqlTypes/MainMenu";
+import { MainMenu_menu_items } from "../MainMenu/gqlTypes/MainMenu";
 import { MainMenuSubItem } from "../MainMenu/gqlTypes/MainMenuSubItem";
 
 interface NavLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   item:
-    | MainMenu_shop_navigation_main_items
+    | MainMenu_menu_items
     | MainMenuSubItem
-    | SecondaryMenu_shop_navigation_secondary_items
-    | SecondaryMenu_shop_navigation_secondary_items_children;
+    | SecondaryMenu_menu_items
+    | SecondaryMenu_menu_items_children;
 }
 export const NavLink: React.FC<NavLinkProps> = ({ item, ...props }) => {
   const { name, url, category, collection, page } = item;

--- a/src/components/OverlayManager/Search/Search.tsx
+++ b/src/components/OverlayManager/Search/Search.tsx
@@ -1,6 +1,7 @@
 import "./scss/index.scss";
 
 import classNames from "classnames";
+import { defaultChannelSlug } from "@temp/constants";
 import { stringify } from "query-string";
 import * as React from "react";
 import {
@@ -131,7 +132,10 @@ class Search extends React.Component<SearchProps, SearchState> {
                       renderOnError
                       displayError={false}
                       errorPolicy="all"
-                      variables={{ query: this.state.search }}
+                      variables={{
+                        channel: defaultChannelSlug,
+                        query: this.state.search,
+                      }}
                     >
                       {({ data, error, loading }) => {
                         if (this.hasResults(data)) {

--- a/src/components/OverlayManager/Search/Search.tsx
+++ b/src/components/OverlayManager/Search/Search.tsx
@@ -1,7 +1,7 @@
 import "./scss/index.scss";
 
 import classNames from "classnames";
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import { stringify } from "query-string";
 import * as React from "react";
 import {
@@ -133,7 +133,7 @@ class Search extends React.Component<SearchProps, SearchState> {
                       displayError={false}
                       errorPolicy="all"
                       variables={{
-                        channel: defaultChannelSlug,
+                        channel: channelSlug,
                         query: this.state.search,
                       }}
                     >

--- a/src/components/OverlayManager/Search/gqlTypes/SearchResults.ts
+++ b/src/components/OverlayManager/Search/gqlTypes/SearchResults.ts
@@ -99,4 +99,5 @@ export interface SearchResults {
 
 export interface SearchResultsVariables {
   query: string;
+  channel?: string | null;
 }

--- a/src/components/OverlayManager/Search/queries.ts
+++ b/src/components/OverlayManager/Search/queries.ts
@@ -7,8 +7,8 @@ import {
 } from "./gqlTypes/SearchResults";
 
 const searchResultsQuery = gql`
-  query SearchResults($query: String!) {
-    products(filter: { search: $query }, first: 20) {
+  query SearchResults($query: String!, $channel: String) {
+    products(filter: { search: $query, channel: $channel }, first: 20) {
       edges {
         node {
           id

--- a/src/components/OverlayManager/Search/queries.ts
+++ b/src/components/OverlayManager/Search/queries.ts
@@ -8,7 +8,7 @@ import {
 
 const searchResultsQuery = gql`
   query SearchResults($query: String!, $channel: String) {
-    products(filter: { search: $query, channel: $channel }, first: 20) {
+    products(filter: { search: $query }, channel: $channel, first: 20) {
       edges {
         node {
           id

--- a/src/components/ProductListItem/index.tsx
+++ b/src/components/ProductListItem/index.tsx
@@ -6,10 +6,10 @@ import * as React from "react";
 import { Thumbnail } from "@components/molecules";
 
 import { TaxedMoney } from "../../@next/components/containers";
-import { FeaturedProducts_shop_homepageCollection_products_edges_node } from "../ProductsFeatured/gqlTypes/FeaturedProducts";
+import { FeaturedProducts_collection_products_edges_node } from "../ProductsFeatured/gqlTypes/FeaturedProducts";
 
 interface ProductListItemProps {
-  product: FeaturedProducts_shop_homepageCollection_products_edges_node;
+  product: FeaturedProducts_collection_products_edges_node;
 }
 
 const ProductListItem: React.FC<ProductListItemProps> = ({ product }) => {

--- a/src/components/ProductsFeatured/gqlTypes/FeaturedProducts.ts
+++ b/src/components/ProductsFeatured/gqlTypes/FeaturedProducts.ts
@@ -6,7 +6,7 @@
 // GraphQL query operation: FeaturedProducts
 // ====================================================
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_thumbnail {
+export interface FeaturedProducts_collection_products_edges_node_thumbnail {
   __typename: "Image";
   /**
    * The URL of the image.
@@ -18,7 +18,7 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_th
   alt: string | null;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_thumbnail2x {
+export interface FeaturedProducts_collection_products_edges_node_thumbnail2x {
   __typename: "Image";
   /**
    * The URL of the image.
@@ -26,7 +26,7 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_th
   url: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_start_gross {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_start_gross {
   __typename: "Money";
   /**
    * Amount of money.
@@ -38,7 +38,7 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_start_net {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_start_net {
   __typename: "Money";
   /**
    * Amount of money.
@@ -50,19 +50,19 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_start {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_start {
   __typename: "TaxedMoney";
   /**
    * Amount of money including taxes.
    */
-  gross: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_start_gross;
+  gross: FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_start_gross;
   /**
    * Amount of money without taxes.
    */
-  net: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_start_net;
+  net: FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_start_net;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_stop_gross {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_stop_gross {
   __typename: "Money";
   /**
    * Amount of money.
@@ -74,7 +74,7 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_stop_net {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_stop_net {
   __typename: "Money";
   /**
    * Amount of money.
@@ -86,31 +86,31 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_stop {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_stop {
   __typename: "TaxedMoney";
   /**
    * Amount of money including taxes.
    */
-  gross: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_stop_gross;
+  gross: FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_stop_gross;
   /**
    * Amount of money without taxes.
    */
-  net: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_stop_net;
+  net: FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_stop_net;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted {
   __typename: "TaxedMoneyRange";
   /**
    * Lower bound of a price range.
    */
-  start: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_start | null;
+  start: FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_start | null;
   /**
    * Upper bound of a price range.
    */
-  stop: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted_stop | null;
+  stop: FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted_stop | null;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_start_gross {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRange_start_gross {
   __typename: "Money";
   /**
    * Amount of money.
@@ -122,7 +122,7 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_start_net {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRange_start_net {
   __typename: "Money";
   /**
    * Amount of money.
@@ -134,19 +134,19 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_start {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRange_start {
   __typename: "TaxedMoney";
   /**
    * Amount of money including taxes.
    */
-  gross: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_start_gross;
+  gross: FeaturedProducts_collection_products_edges_node_pricing_priceRange_start_gross;
   /**
    * Amount of money without taxes.
    */
-  net: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_start_net;
+  net: FeaturedProducts_collection_products_edges_node_pricing_priceRange_start_net;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_stop_gross {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRange_stop_gross {
   __typename: "Money";
   /**
    * Amount of money.
@@ -158,7 +158,7 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_stop_net {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRange_stop_net {
   __typename: "Money";
   /**
    * Amount of money.
@@ -170,31 +170,31 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   currency: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_stop {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRange_stop {
   __typename: "TaxedMoney";
   /**
    * Amount of money including taxes.
    */
-  gross: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_stop_gross;
+  gross: FeaturedProducts_collection_products_edges_node_pricing_priceRange_stop_gross;
   /**
    * Amount of money without taxes.
    */
-  net: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_stop_net;
+  net: FeaturedProducts_collection_products_edges_node_pricing_priceRange_stop_net;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange {
+export interface FeaturedProducts_collection_products_edges_node_pricing_priceRange {
   __typename: "TaxedMoneyRange";
   /**
    * Lower bound of a price range.
    */
-  start: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_start | null;
+  start: FeaturedProducts_collection_products_edges_node_pricing_priceRange_start | null;
   /**
    * Upper bound of a price range.
    */
-  stop: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange_stop | null;
+  stop: FeaturedProducts_collection_products_edges_node_pricing_priceRange_stop | null;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pricing {
+export interface FeaturedProducts_collection_products_edges_node_pricing {
   __typename: "ProductPricingInfo";
   /**
    * Whether it is in sale or not.
@@ -203,14 +203,14 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_pr
   /**
    * The undiscounted price range of the product variants.
    */
-  priceRangeUndiscounted: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRangeUndiscounted | null;
+  priceRangeUndiscounted: FeaturedProducts_collection_products_edges_node_pricing_priceRangeUndiscounted | null;
   /**
    * The discounted price range of the product variants.
    */
-  priceRange: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing_priceRange | null;
+  priceRange: FeaturedProducts_collection_products_edges_node_pricing_priceRange | null;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node_category {
+export interface FeaturedProducts_collection_products_edges_node_category {
   __typename: "Category";
   /**
    * The ID of the object.
@@ -219,7 +219,7 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node_ca
   name: string;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges_node {
+export interface FeaturedProducts_collection_products_edges_node {
   __typename: "Product";
   /**
    * The ID of the object.
@@ -229,54 +229,47 @@ export interface FeaturedProducts_shop_homepageCollection_products_edges_node {
   /**
    * The main thumbnail for a product.
    */
-  thumbnail: FeaturedProducts_shop_homepageCollection_products_edges_node_thumbnail | null;
+  thumbnail: FeaturedProducts_collection_products_edges_node_thumbnail | null;
   /**
    * The main thumbnail for a product.
    */
-  thumbnail2x: FeaturedProducts_shop_homepageCollection_products_edges_node_thumbnail2x | null;
+  thumbnail2x: FeaturedProducts_collection_products_edges_node_thumbnail2x | null;
   /**
    * Lists the storefront product's pricing, the current price and discounts, only meant for displaying.
    */
-  pricing: FeaturedProducts_shop_homepageCollection_products_edges_node_pricing | null;
-  category: FeaturedProducts_shop_homepageCollection_products_edges_node_category | null;
+  pricing: FeaturedProducts_collection_products_edges_node_pricing | null;
+  category: FeaturedProducts_collection_products_edges_node_category | null;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products_edges {
+export interface FeaturedProducts_collection_products_edges {
   __typename: "ProductCountableEdge";
   /**
    * The item at the end of the edge.
    */
-  node: FeaturedProducts_shop_homepageCollection_products_edges_node;
+  node: FeaturedProducts_collection_products_edges_node;
 }
 
-export interface FeaturedProducts_shop_homepageCollection_products {
+export interface FeaturedProducts_collection_products {
   __typename: "ProductCountableConnection";
-  edges: FeaturedProducts_shop_homepageCollection_products_edges[];
+  edges: FeaturedProducts_collection_products_edges[];
 }
 
-export interface FeaturedProducts_shop_homepageCollection {
+export interface FeaturedProducts_collection {
   __typename: "Collection";
-  /**
-   * The ID of the object.
-   */
-  id: string;
+  name: string;
   /**
    * List of products in this collection.
    */
-  products: FeaturedProducts_shop_homepageCollection_products | null;
-}
-
-export interface FeaturedProducts_shop {
-  __typename: "Shop";
-  /**
-   * Collection displayed on homepage.
-   */
-  homepageCollection: FeaturedProducts_shop_homepageCollection | null;
+  products: FeaturedProducts_collection_products | null;
 }
 
 export interface FeaturedProducts {
   /**
-   * Return information about the shop.
+   * Look up a collection by ID.
    */
-  shop: FeaturedProducts_shop;
+  collection: FeaturedProducts_collection | null;
+}
+
+export interface FeaturedProductsVariables {
+  channel?: string | null;
 }

--- a/src/components/ProductsFeatured/index.tsx
+++ b/src/components/ProductsFeatured/index.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 
+import { defaultChannelSlug } from "@temp/constants";
 import { Carousel, ProductListItem } from "..";
-import { generateProductUrl, maybe } from "../../core/utils";
+import { generateProductUrl } from "../../core/utils";
 import { TypedFeaturedProductsQuery } from "./queries";
 
 import "./scss/index.scss";
@@ -13,12 +14,12 @@ interface ProductsFeaturedProps {
 
 const ProductsFeatured: React.FC<ProductsFeaturedProps> = ({ title }) => {
   return (
-    <TypedFeaturedProductsQuery displayError={false}>
+    <TypedFeaturedProductsQuery
+      displayError={false}
+      variables={{ channel: defaultChannelSlug }}
+    >
       {({ data }) => {
-        const products = maybe(
-          () => data.shop.homepageCollection.products.edges,
-          []
-        );
+        const products = data.collection?.products?.edges || [];
 
         if (products.length) {
           return (

--- a/src/components/ProductsFeatured/index.tsx
+++ b/src/components/ProductsFeatured/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import { Carousel, ProductListItem } from "..";
 import { generateProductUrl } from "../../core/utils";
 import { TypedFeaturedProductsQuery } from "./queries";
@@ -16,7 +16,7 @@ const ProductsFeatured: React.FC<ProductsFeaturedProps> = ({ title }) => {
   return (
     <TypedFeaturedProductsQuery
       displayError={false}
-      variables={{ channel: defaultChannelSlug }}
+      variables={{ channel: channelSlug }}
     >
       {({ data }) => {
         const products = data.collection?.products?.edges || [];

--- a/src/components/ProductsFeatured/queries.tsx
+++ b/src/components/ProductsFeatured/queries.tsx
@@ -5,24 +5,25 @@ import {
   basicProductFragment,
   productPricingFragment,
 } from "../../views/Product/queries";
-import { FeaturedProducts } from "./gqlTypes/FeaturedProducts";
+import {
+  FeaturedProducts,
+  FeaturedProductsVariables,
+} from "./gqlTypes/FeaturedProducts";
 
 export const featuredProducts = gql`
   ${basicProductFragment}
   ${productPricingFragment}
-  query FeaturedProducts {
-    shop {
-      homepageCollection {
-        id
-        products(first: 20) {
-          edges {
-            node {
-              ...BasicProductFields
-              ...ProductPricingField
-              category {
-                id
-                name
-              }
+  query FeaturedProducts($channel: String) {
+    collection(slug: "featured-products", channel: $channel) {
+      name
+      products(first: 20) {
+        edges {
+          node {
+            ...BasicProductFields
+            ...ProductPricingField
+            category {
+              id
+              name
             }
           }
         }
@@ -31,6 +32,7 @@ export const featuredProducts = gql`
   }
 `;
 
-export const TypedFeaturedProductsQuery = TypedQuery<FeaturedProducts, {}>(
-  featuredProducts
-);
+export const TypedFeaturedProductsQuery = TypedQuery<
+  FeaturedProducts,
+  FeaturedProductsVariables
+>(featuredProducts);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,4 +5,4 @@ export const sentrySampleRate = isNaN(sampleRate) ? 0 : sampleRate;
 export const serviceWorkerTimeout =
   parseInt(process.env.SERVICE_WORKER_TIMEOUT, 10) || 60 * 1000;
 export const demoMode = process.env.DEMO_MODE === "true";
-export const defaultChannelSlug = process.env.DEFAULT_CHANNEL_SLUG;
+export const channelSlug = process.env.SALEOR_CHANNEL_SLUG;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,4 @@ export const sentrySampleRate = isNaN(sampleRate) ? 0 : sampleRate;
 export const serviceWorkerTimeout =
   parseInt(process.env.SERVICE_WORKER_TIMEOUT, 10) || 60 * 1000;
 export const demoMode = process.env.DEMO_MODE === "true";
+export const defaultChannelSlug = process.env.DEFAULT_CHANNEL_SLUG;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import { App } from "./app";
 import { LocaleProvider } from "./components/Locale";
 import {
   apiUrl,
-  defaultChannelSlug,
+  channelSlug,
   sentryDsn,
   sentrySampleRate,
   serviceWorkerTimeout,
@@ -28,7 +28,7 @@ import { history } from "./history";
 
 const SALEOR_CONFIG: ConfigInput = {
   apiUrl,
-  channel: defaultChannelSlug,
+  channel: channelSlug,
 };
 
 if (process.env.GTM_ID !== undefined) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import { App } from "./app";
 import { LocaleProvider } from "./components/Locale";
 import {
   apiUrl,
+  defaultChannelSlug,
   sentryDsn,
   sentrySampleRate,
   serviceWorkerTimeout,
@@ -27,6 +28,7 @@ import { history } from "./history";
 
 const SALEOR_CONFIG: ConfigInput = {
   apiUrl,
+  channel: defaultChannelSlug,
 };
 
 if (process.env.GTM_ID !== undefined) {

--- a/src/sitemap/fetchItems.ts
+++ b/src/sitemap/fetchItems.ts
@@ -15,6 +15,7 @@ import {
 } from "./queries";
 
 const API_URL = process.env.API_URI || "/graphql/";
+const DEFAULT_CHANNEL_SLUG = process.env.DEFAULT_CHANNEL_SLUG || "";
 
 const fetchItems = async ({ query, perPage = 100 }, callback: any) => {
   const client = new ApolloClient({
@@ -24,7 +25,7 @@ const fetchItems = async ({ query, perPage = 100 }, callback: any) => {
   const next = async (cursor = null) => {
     const response = await client.query({
       query,
-      variables: { perPage, cursor },
+      variables: { perPage, cursor, channel: DEFAULT_CHANNEL_SLUG },
     });
     const data =
       response.data[query.definitions[0].selectionSet.selections[0].name.value];

--- a/src/sitemap/fetchItems.ts
+++ b/src/sitemap/fetchItems.ts
@@ -15,7 +15,7 @@ import {
 } from "./queries";
 
 const API_URL = process.env.API_URI || "/graphql/";
-const DEFAULT_CHANNEL_SLUG = process.env.DEFAULT_CHANNEL_SLUG || "";
+const DEFAULT_CHANNEL = process.env.SALEOR_CHANNEL_SLUG || "default-channel";
 
 const fetchItems = async ({ query, perPage = 100 }, callback: any) => {
   const client = new ApolloClient({
@@ -25,7 +25,7 @@ const fetchItems = async ({ query, perPage = 100 }, callback: any) => {
   const next = async (cursor = null) => {
     const response = await client.query({
       query,
-      variables: { perPage, cursor, channel: DEFAULT_CHANNEL_SLUG },
+      variables: { perPage, cursor, channel: DEFAULT_CHANNEL },
     });
     const data =
       response.data[query.definitions[0].selectionSet.selections[0].name.value];

--- a/src/sitemap/gqlTypes/GetCollections.ts
+++ b/src/sitemap/gqlTypes/GetCollections.ts
@@ -54,4 +54,5 @@ export interface GetCollections {
 export interface GetCollectionsVariables {
   cursor?: string | null;
   perPage?: number | null;
+  channel?: string | null;
 }

--- a/src/sitemap/gqlTypes/GetProducts.ts
+++ b/src/sitemap/gqlTypes/GetProducts.ts
@@ -54,4 +54,5 @@ export interface GetProducts {
 export interface GetProductsVariables {
   cursor?: string | null;
   perPage?: number | null;
+  channel?: string | null;
 }

--- a/src/sitemap/queries.ts
+++ b/src/sitemap/queries.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
 
 export const getProductsQuery = gql`
-  query GetProducts($cursor: String, $perPage: Int) {
-    products(after: $cursor, first: $perPage) {
+  query GetProducts($cursor: String, $perPage: Int, $channel: String) {
+    products(after: $cursor, first: $perPage, channel: $channel) {
       pageInfo {
         endCursor
         hasNextPage
@@ -35,8 +35,8 @@ export const getCategoriesQuery = gql`
 `;
 
 export const getCollectionsQuery = gql`
-  query GetCollections($cursor: String, $perPage: Int) {
-    collections(after: $cursor, first: $perPage) {
+  query GetCollections($cursor: String, $perPage: Int, $channel: String) {
+    collections(after: $cursor, first: $perPage, channel: $channel) {
       pageInfo {
         endCursor
         hasNextPage

--- a/src/views/Article/View.tsx
+++ b/src/views/Article/View.tsx
@@ -3,7 +3,7 @@ import "./scss/index.scss";
 import * as React from "react";
 import { RouteComponentProps } from "react-router-dom";
 
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import { MetaWrapper, NotFound } from "../../components";
 import { STATIC_PAGES } from "../../core/config";
 import { generatePageUrl, maybe } from "../../core/utils";
@@ -25,7 +25,7 @@ export const View: React.FC<ViewProps> = ({
 }) => (
   <TypedArticleQuery
     loaderFull
-    variables={{ slug, channel: defaultChannelSlug }}
+    variables={{ slug, channel: channelSlug }}
     errorPolicy="all"
   >
     {({ data }) => {

--- a/src/views/Article/View.tsx
+++ b/src/views/Article/View.tsx
@@ -3,17 +3,18 @@ import "./scss/index.scss";
 import * as React from "react";
 import { RouteComponentProps } from "react-router-dom";
 
+import { defaultChannelSlug } from "@temp/constants";
 import { MetaWrapper, NotFound } from "../../components";
 import { STATIC_PAGES } from "../../core/config";
 import { generatePageUrl, maybe } from "../../core/utils";
-import { Article_shop } from "./gqlTypes/Article";
+import { Article_collection } from "./gqlTypes/Article";
 import Page from "./Page";
 import { TypedArticleQuery } from "./query";
 
 const canDisplay = page =>
   maybe(() => !!page && !!page.title && !!page.contentJson);
-const getHeaderImage = (shop: Article_shop) =>
-  maybe(() => shop.homepageCollection.backgroundImage.url);
+const getHeaderImage = (collection: Article_collection) =>
+  maybe(() => collection.backgroundImage.url);
 
 type ViewProps = RouteComponentProps<{ slug: string }>;
 
@@ -22,13 +23,17 @@ export const View: React.FC<ViewProps> = ({
     params: { slug },
   },
 }) => (
-  <TypedArticleQuery loaderFull variables={{ slug }} errorPolicy="all">
+  <TypedArticleQuery
+    loaderFull
+    variables={{ slug, channel: defaultChannelSlug }}
+    errorPolicy="all"
+  >
     {({ data }) => {
       const navigation = STATIC_PAGES.map(page => ({
         ...page,
         active: page.url === window.location.pathname,
       }));
-      const { page, shop } = data;
+      const { page, collection } = data;
 
       if (canDisplay(page)) {
         const breadcrumbs = [
@@ -46,7 +51,7 @@ export const View: React.FC<ViewProps> = ({
           >
             <Page
               breadcrumbs={breadcrumbs}
-              headerImage={getHeaderImage(shop)}
+              headerImage={getHeaderImage(collection)}
               navigation={navigation}
               page={data.page}
             />

--- a/src/views/Article/gqlTypes/Article.ts
+++ b/src/views/Article/gqlTypes/Article.ts
@@ -19,7 +19,7 @@ export interface Article_page {
   title: string;
 }
 
-export interface Article_shop_homepageCollection_backgroundImage {
+export interface Article_collection_backgroundImage {
   __typename: "Image";
   /**
    * The URL of the image.
@@ -27,21 +27,13 @@ export interface Article_shop_homepageCollection_backgroundImage {
   url: string;
 }
 
-export interface Article_shop_homepageCollection {
+export interface Article_collection {
   __typename: "Collection";
   /**
    * The ID of the object.
    */
   id: string;
-  backgroundImage: Article_shop_homepageCollection_backgroundImage | null;
-}
-
-export interface Article_shop {
-  __typename: "Shop";
-  /**
-   * Collection displayed on homepage.
-   */
-  homepageCollection: Article_shop_homepageCollection | null;
+  backgroundImage: Article_collection_backgroundImage | null;
 }
 
 export interface Article {
@@ -50,11 +42,12 @@ export interface Article {
    */
   page: Article_page | null;
   /**
-   * Return information about the shop.
+   * Look up a collection by ID.
    */
-  shop: Article_shop;
+  collection: Article_collection | null;
 }
 
 export interface ArticleVariables {
   slug: string;
+  channel?: string | null;
 }

--- a/src/views/Article/query.ts
+++ b/src/views/Article/query.ts
@@ -4,7 +4,7 @@ import { TypedQuery } from "../../core/queries";
 import { Article, ArticleVariables } from "./gqlTypes/Article";
 
 const articleQuery = gql`
-  query Article($slug: String!) {
+  query Article($slug: String!, $channel: String) {
     page(slug: $slug) {
       contentJson
       id
@@ -13,12 +13,10 @@ const articleQuery = gql`
       slug
       title
     }
-    shop {
-      homepageCollection {
-        id
-        backgroundImage {
-          url
-        }
+    collection(slug: "featured-products", channel: $channel) {
+      id
+      backgroundImage {
+        url
       }
     }
   }

--- a/src/views/Category/View.tsx
+++ b/src/views/Category/View.tsx
@@ -4,6 +4,7 @@ import { RouteComponentProps } from "react-router";
 
 import { prodListHeaderCommonMsg } from "@temp/intl";
 import { IFilters } from "@types";
+import { defaultChannelSlug } from "@temp/constants";
 import { StringParam, useQueryParam } from "use-query-params";
 import { Loader, OfflinePlaceholder } from "@components/atoms";
 import { MetaWrapper, NotFound } from "../../components";
@@ -96,6 +97,7 @@ export const View: React.FC<ViewProps> = ({ match }) => {
     attributes: filters.attributes
       ? convertToAttributeScalar(filters.attributes)
       : {},
+    channel: defaultChannelSlug,
     id: getGraphqlIdFromDBId(match.params.id, "Category"),
     sortBy: convertSortByFromString(filters.sortBy),
   };

--- a/src/views/Category/View.tsx
+++ b/src/views/Category/View.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps } from "react-router";
 
 import { prodListHeaderCommonMsg } from "@temp/intl";
 import { IFilters } from "@types";
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import { StringParam, useQueryParam } from "use-query-params";
 import { Loader, OfflinePlaceholder } from "@components/atoms";
 import { MetaWrapper, NotFound } from "../../components";
@@ -97,7 +97,7 @@ export const View: React.FC<ViewProps> = ({ match }) => {
     attributes: filters.attributes
       ? convertToAttributeScalar(filters.attributes)
       : {},
-    channel: defaultChannelSlug,
+    channel: channelSlug,
     id: getGraphqlIdFromDBId(match.params.id, "Category"),
     sortBy: convertSortByFromString(filters.sortBy),
   };

--- a/src/views/Category/gqlTypes/Category.ts
+++ b/src/views/Category/gqlTypes/Category.ts
@@ -114,4 +114,5 @@ export interface Category {
 
 export interface CategoryVariables {
   id: string;
+  channel?: string | null;
 }

--- a/src/views/Category/gqlTypes/CategoryProducts.ts
+++ b/src/views/Category/gqlTypes/CategoryProducts.ts
@@ -293,7 +293,7 @@ export interface CategoryProducts {
 
 export interface CategoryProductsVariables {
   id: string;
-  channel: string;
+  channel?: string | null;
   attributes?: (AttributeInput | null)[] | null;
   after?: string | null;
   pageSize?: number | null;

--- a/src/views/Category/gqlTypes/CategoryProducts.ts
+++ b/src/views/Category/gqlTypes/CategoryProducts.ts
@@ -293,6 +293,7 @@ export interface CategoryProducts {
 
 export interface CategoryProductsVariables {
   id: string;
+  channel: string;
   attributes?: (AttributeInput | null)[] | null;
   after?: string | null;
   pageSize?: number | null;

--- a/src/views/Category/queries.ts
+++ b/src/views/Category/queries.ts
@@ -12,7 +12,7 @@ import {
 } from "./gqlTypes/CategoryProducts";
 
 export const categoryProductsDataQuery = gql`
-  query Category($id: ID!) {
+  query Category($id: ID!, $channel: String) {
     category(id: $id) {
       seoDescription
       seoTitle
@@ -31,7 +31,11 @@ export const categoryProductsDataQuery = gql`
       }
     }
     attributes(
-      filter: { inCategory: $id, filterableInStorefront: true }
+      filter: {
+        inCategory: $id
+        filterableInStorefront: true
+        channel: $channel
+      }
       first: 100
     ) {
       edges {
@@ -60,6 +64,7 @@ export const categoryProductsQuery = gql`
   ${productPricingFragment}
   query CategoryProducts(
     $id: ID!
+    $channel: String!
     $attributes: [AttributeInput]
     $after: String
     $pageSize: Int
@@ -75,7 +80,9 @@ export const categoryProductsQuery = gql`
         attributes: $attributes
         categories: [$id]
         minimalPrice: { gte: $priceGte, lte: $priceLte }
+        channel: $channel
       }
+      channel: $channel
     ) {
       totalCount
       edges {

--- a/src/views/Category/queries.ts
+++ b/src/views/Category/queries.ts
@@ -64,7 +64,7 @@ export const categoryProductsQuery = gql`
   ${productPricingFragment}
   query CategoryProducts(
     $id: ID!
-    $channel: String!
+    $channel: String
     $attributes: [AttributeInput]
     $after: String
     $pageSize: Int

--- a/src/views/Home/Page.tsx
+++ b/src/views/Home/Page.tsx
@@ -11,7 +11,7 @@ import { generateCategoryUrl } from "../../core/utils";
 import {
   ProductsList_categories,
   ProductsList_shop,
-  ProductsList_shop_homepageCollection_backgroundImage,
+  ProductsList_collection_backgroundImage,
 } from "./gqlTypes/ProductsList";
 
 import { structuredData } from "../../core/SEO/Homepage/structuredData";
@@ -21,7 +21,7 @@ import noPhotoImg from "../../images/no-photo.svg";
 const Page: React.FC<{
   loading: boolean;
   categories: ProductsList_categories;
-  backgroundImage: ProductsList_shop_homepageCollection_backgroundImage;
+  backgroundImage: ProductsList_collection_backgroundImage;
   shop: ProductsList_shop;
 }> = ({ loading, categories, backgroundImage, shop }) => {
   const categoriesExist = () => {

--- a/src/views/Home/View.tsx
+++ b/src/views/Home/View.tsx
@@ -2,7 +2,7 @@ import "./scss/index.scss";
 
 import * as React from "react";
 
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import { MetaWrapper } from "../../components";
 import Page from "./Page";
 import { TypedHomePageQuery } from "./queries";
@@ -12,7 +12,7 @@ const View: React.FC = () => (
     <TypedHomePageQuery
       alwaysRender
       displayLoader={false}
-      variables={{ channel: defaultChannelSlug }}
+      variables={{ channel: channelSlug }}
       errorPolicy="all"
     >
       {({ data, loading }) => {

--- a/src/views/Home/View.tsx
+++ b/src/views/Home/View.tsx
@@ -2,13 +2,19 @@ import "./scss/index.scss";
 
 import * as React from "react";
 
+import { defaultChannelSlug } from "@temp/constants";
 import { MetaWrapper } from "../../components";
 import Page from "./Page";
 import { TypedHomePageQuery } from "./queries";
 
 const View: React.FC = () => (
   <div className="home-page">
-    <TypedHomePageQuery alwaysRender displayLoader={false} errorPolicy="all">
+    <TypedHomePageQuery
+      alwaysRender
+      displayLoader={false}
+      variables={{ channel: defaultChannelSlug }}
+      errorPolicy="all"
+    >
       {({ data, loading }) => {
         return (
           <MetaWrapper
@@ -19,11 +25,7 @@ const View: React.FC = () => (
           >
             <Page
               loading={loading}
-              backgroundImage={
-                data.shop &&
-                data.shop.homepageCollection &&
-                data.shop.homepageCollection.backgroundImage
-              }
+              backgroundImage={data.collection?.backgroundImage}
               categories={data.categories}
               shop={data.shop}
             />

--- a/src/views/Home/gqlTypes/ProductsList.ts
+++ b/src/views/Home/gqlTypes/ProductsList.ts
@@ -6,24 +6,6 @@
 // GraphQL query operation: ProductsList
 // ====================================================
 
-export interface ProductsList_shop_homepageCollection_backgroundImage {
-  __typename: "Image";
-  /**
-   * The URL of the image.
-   */
-  url: string;
-}
-
-export interface ProductsList_shop_homepageCollection {
-  __typename: "Collection";
-  /**
-   * The ID of the object.
-   */
-  id: string;
-  backgroundImage: ProductsList_shop_homepageCollection_backgroundImage | null;
-  name: string;
-}
-
 export interface ProductsList_shop {
   __typename: "Shop";
   /**
@@ -34,10 +16,23 @@ export interface ProductsList_shop {
    * Shop's name.
    */
   name: string;
+}
+
+export interface ProductsList_collection_backgroundImage {
+  __typename: "Image";
   /**
-   * Collection displayed on homepage.
+   * The URL of the image.
    */
-  homepageCollection: ProductsList_shop_homepageCollection | null;
+  url: string;
+  /**
+   * Alt text for an image.
+   */
+  alt: string | null;
+}
+
+export interface ProductsList_collection {
+  __typename: "Collection";
+  backgroundImage: ProductsList_collection_backgroundImage | null;
 }
 
 export interface ProductsList_categories_edges_node_backgroundImage {
@@ -77,7 +72,15 @@ export interface ProductsList {
    */
   shop: ProductsList_shop;
   /**
+   * Look up a collection by ID.
+   */
+  collection: ProductsList_collection | null;
+  /**
    * List of the shop's categories.
    */
   categories: ProductsList_categories | null;
+}
+
+export interface ProductsListVariables {
+  channel?: string | null;
 }

--- a/src/views/Home/queries.ts
+++ b/src/views/Home/queries.ts
@@ -4,16 +4,15 @@ import { TypedQuery } from "../../core/queries";
 import { ProductsList } from "./gqlTypes/ProductsList";
 
 export const homePageQuery = gql`
-  query ProductsList {
+  query ProductsList($channel: String) {
     shop {
       description
       name
-      homepageCollection {
-        id
-        backgroundImage {
-          url
-        }
-        name
+    }
+    collection(slug: "featured-products", channel: $channel) {
+      backgroundImage {
+        url
+        alt
       }
     }
     categories(level: 0, first: 4) {

--- a/src/views/Product/View.tsx
+++ b/src/views/Product/View.tsx
@@ -1,7 +1,7 @@
 import "./scss/index.scss";
 
 import { useCart } from "@saleor/sdk";
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import { isEmpty } from "lodash";
 import queryString from "query-string";
 import React, { useEffect, useState } from "react";
@@ -116,7 +116,7 @@ const View: React.FC<RouteComponentProps<{ id: string }>> = ({ match }) => {
     <TypedProductDetailsQuery
       loaderFull
       variables={{
-        channel: defaultChannelSlug,
+        channel: channelSlug,
         id: getGraphqlIdFromDBId(match.params.id, "Product"),
       }}
       errorPolicy="all"

--- a/src/views/Product/View.tsx
+++ b/src/views/Product/View.tsx
@@ -1,6 +1,7 @@
 import "./scss/index.scss";
 
 import { useCart } from "@saleor/sdk";
+import { defaultChannelSlug } from "@temp/constants";
 import { isEmpty } from "lodash";
 import queryString from "query-string";
 import React, { useEffect, useState } from "react";
@@ -115,6 +116,7 @@ const View: React.FC<RouteComponentProps<{ id: string }>> = ({ match }) => {
     <TypedProductDetailsQuery
       loaderFull
       variables={{
+        channel: defaultChannelSlug,
         id: getGraphqlIdFromDBId(match.params.id, "Product"),
       }}
       errorPolicy="all"

--- a/src/views/Product/gqlTypes/ProductDetails.ts
+++ b/src/views/Product/gqlTypes/ProductDetails.ts
@@ -730,6 +730,9 @@ export interface ProductDetails_product {
    * Whether the product is available for purchase.
    */
   isAvailableForPurchase: boolean | null;
+  /**
+   * Date when product is available for purchase. 
+   */
   availableForPurchase: any | null;
 }
 
@@ -742,5 +745,6 @@ export interface ProductDetails {
 
 export interface ProductDetailsVariables {
   id: string;
+  channel: string;
   countryCode?: CountryCode | null;
 }

--- a/src/views/Product/gqlTypes/ProductDetails.ts
+++ b/src/views/Product/gqlTypes/ProductDetails.ts
@@ -745,6 +745,6 @@ export interface ProductDetails {
 
 export interface ProductDetailsVariables {
   id: string;
-  channel: string;
+  channel?: string | null;
   countryCode?: CountryCode | null;
 }

--- a/src/views/Product/gqlTypes/VariantList.ts
+++ b/src/views/Product/gqlTypes/VariantList.ts
@@ -243,6 +243,6 @@ export interface VariantList {
 
 export interface VariantListVariables {
   ids?: string[] | null;
-  channel: string;
+  channel?: string | null;
   countryCode?: CountryCode | null;
 }

--- a/src/views/Product/gqlTypes/VariantList.ts
+++ b/src/views/Product/gqlTypes/VariantList.ts
@@ -243,5 +243,6 @@ export interface VariantList {
 
 export interface VariantListVariables {
   ids?: string[] | null;
+  channel: string;
   countryCode?: CountryCode | null;
 }

--- a/src/views/Product/queries.ts
+++ b/src/views/Product/queries.ts
@@ -113,7 +113,7 @@ export const productDetailsQuery = gql`
   ${selectedAttributeFragment}
   ${productVariantFragment}
   ${productPricingFragment}
-  query ProductDetails($id: ID!, $channel: String!, $countryCode: CountryCode) {
+  query ProductDetails($id: ID!, $channel: String, $countryCode: CountryCode) {
     product(id: $id, channel: $channel) {
       ...BasicProductFields
       ...ProductPricingField
@@ -155,7 +155,7 @@ export const productDetailsQuery = gql`
 export const productVariantsQuery = gql`
   ${basicProductFragment}
   ${productVariantFragment}
-  query VariantList($ids: [ID!], $channel: String!, $countryCode: CountryCode) {
+  query VariantList($ids: [ID!], $channel: String, $countryCode: CountryCode) {
     productVariants(ids: $ids, first: 100, channel: $channel) {
       edges {
         node {

--- a/src/views/Product/queries.ts
+++ b/src/views/Product/queries.ts
@@ -113,15 +113,15 @@ export const productDetailsQuery = gql`
   ${selectedAttributeFragment}
   ${productVariantFragment}
   ${productPricingFragment}
-  query ProductDetails($id: ID!, $countryCode: CountryCode) {
-    product(id: $id) {
+  query ProductDetails($id: ID!, $channel: String!, $countryCode: CountryCode) {
+    product(id: $id, channel: $channel) {
       ...BasicProductFields
       ...ProductPricingField
       descriptionJson
       category {
         id
         name
-        products(first: 3) {
+        products(first: 3, channel: $channel) {
           edges {
             node {
               ...BasicProductFields
@@ -155,8 +155,8 @@ export const productDetailsQuery = gql`
 export const productVariantsQuery = gql`
   ${basicProductFragment}
   ${productVariantFragment}
-  query VariantList($ids: [ID!], $countryCode: CountryCode) {
-    productVariants(ids: $ids, first: 100) {
+  query VariantList($ids: [ID!], $channel: String!, $countryCode: CountryCode) {
+    productVariants(ids: $ids, first: 100, channel: $channel) {
       edges {
         node {
           ...ProductVariantFields

--- a/src/views/Search/View.tsx
+++ b/src/views/Search/View.tsx
@@ -6,7 +6,7 @@ import { prodListHeaderCommonMsg } from "@temp/intl";
 import { IFilters } from "@types";
 import { StringParam, useQueryParam } from "use-query-params";
 import { OfflinePlaceholder } from "@components/atoms";
-import { defaultChannelSlug } from "@temp/constants";
+import { channelSlug } from "@temp/constants";
 import { NotFound } from "../../components";
 import NetworkStatus from "../../components/NetworkStatus";
 import { PRODUCTS_PER_PAGE } from "../../core/config";
@@ -64,7 +64,7 @@ export const View: React.FC<ViewProps> = ({ match }) => {
     attributes: filters.attributes
       ? convertToAttributeScalar(filters.attributes)
       : {},
-    channel: defaultChannelSlug,
+    channel: channelSlug,
     id: getGraphqlIdFromDBId(match.params.id, "Category"),
     query: search || null,
     sortBy: convertSortByFromString(filters.sortBy),

--- a/src/views/Search/View.tsx
+++ b/src/views/Search/View.tsx
@@ -6,6 +6,7 @@ import { prodListHeaderCommonMsg } from "@temp/intl";
 import { IFilters } from "@types";
 import { StringParam, useQueryParam } from "use-query-params";
 import { OfflinePlaceholder } from "@components/atoms";
+import { defaultChannelSlug } from "@temp/constants";
 import { NotFound } from "../../components";
 import NetworkStatus from "../../components/NetworkStatus";
 import { PRODUCTS_PER_PAGE } from "../../core/config";
@@ -63,6 +64,7 @@ export const View: React.FC<ViewProps> = ({ match }) => {
     attributes: filters.attributes
       ? convertToAttributeScalar(filters.attributes)
       : {},
+    channel: defaultChannelSlug,
     id: getGraphqlIdFromDBId(match.params.id, "Category"),
     query: search || null,
     sortBy: convertSortByFromString(filters.sortBy),

--- a/src/views/Search/gqlTypes/SearchProducts.ts
+++ b/src/views/Search/gqlTypes/SearchProducts.ts
@@ -338,6 +338,7 @@ export interface SearchProducts {
 
 export interface SearchProductsVariables {
   query: string;
+  channel: string;
   attributes?: (AttributeInput | null)[] | null;
   pageSize?: number | null;
   sortBy?: ProductOrder | null;

--- a/src/views/Search/queries.ts
+++ b/src/views/Search/queries.ts
@@ -11,12 +11,14 @@ export const searchProductsQuery = gql`
   ${productPricingFragment}
   query SearchProducts(
     $query: String!
+    $channel: String!
     $attributes: [AttributeInput]
     $pageSize: Int
     $sortBy: ProductOrder
     $after: String
   ) {
     products(
+      channel: $channel
       filter: { search: $query, attributes: $attributes }
       first: $pageSize
       sortBy: $sortBy


### PR DESCRIPTION
I want to merge this change because...

- Store the channel slug in the storefront 
- Update queries that require channel slug and pass the value to these queries to get channel’s data.
- Update featured products - use products from channel with featured-products slug

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/