### PR TITLE
[1654] Use next SDK version (user channel token)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6119,9 +6119,9 @@
       }
     },
     "@saleor/sdk": {
-      "version": "0.3.0-0",
-      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.3.0-0.tgz",
-      "integrity": "sha512-p0jlZFYcmv8Gexfl3WNq7FSMGo6gcxc+LuNYnVNYnXDyBEJE9cQ31/id+NaoJ5l9fSrLRM/LyJF3ICgU0eFT0Q==",
+      "version": "0.3.0-2",
+      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.3.0-2.tgz",
+      "integrity": "sha512-/NSHOj5zs5xdgOD6sp1diMhXy0lqsbCOJMXKLcyp89GQ2GyfP7efvyXNpGUdfNKVJpdHIy3RKlkwXhTYZq/T1A==",
       "requires": {
         "apollo-cache": "^1.3.5",
         "apollo-cache-inmemory": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@editorjs/list": "^1.6.0",
     "@editorjs/quote": "^2.4.0",
     "@lhci/cli": "^0.4.1",
-    "@saleor/sdk": "^0.3.0-0",
+    "@saleor/sdk": "^0.3.0-2",
     "@sentry/apm": "^5.15.5",
     "@sentry/browser": "^5.15.5",
     "@stripe/react-stripe-js": "^1.1.2",


### PR DESCRIPTION
I want to merge this change because...
Adjusts user checkout query which is now split into 2 queries (first returns list of tokens and the second queries the details)
<!-- Please mention all relevant issue numbers. -->
https://app.clickup.com/t/2549495/SALEOR-1654

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
