### PR TITLE
Saleor 1775 thumbnail size issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add EditorJS renderer - #947 by @krzysztofwolski
 - New cart sidebar - #907 by @orzechdev
 - Support for multichannel - #937 by @AlicjaSzu
+- Fixed image scaling in gallery and thumbnails - #959 by @MarekChoinski
 
 ## 2.11.0
 

--- a/src/@next/components/molecules/OrderTabel/__snapshots__/stories.storyshot
+++ b/src/@next/components/molecules/OrderTabel/__snapshots__/stories.storyshot
@@ -86,6 +86,7 @@ exports[`Storyshots @components/molecules/OrderTabel default 1`] = `
 
 .c4 img {
   max-width: 50px;
+  max-height: 50px;
   height: auto;
 }
 

--- a/src/@next/components/molecules/OrderTabel/styles.ts
+++ b/src/@next/components/molecules/OrderTabel/styles.ts
@@ -34,6 +34,7 @@ export const ProductsOrdered = styled.div`
 
   img {
     max-width: 50px;
+    max-height: 50px;
     height: auto;
   }
 `;

--- a/src/@next/components/molecules/ProductTile/__snapshots__/stories.storyshot
+++ b/src/@next/components/molecules/ProductTile/__snapshots__/stories.storyshot
@@ -22,6 +22,14 @@ exports[`Storyshots @components/molecules/ProductTile default 1`] = `
   padding: 2.5rem;
   text-align: center;
   max-height: 30rem;
+  height: 26rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   -webkit-transition: 0.3s;
   transition: 0.3s;
 }
@@ -45,15 +53,23 @@ exports[`Storyshots @components/molecules/ProductTile default 1`] = `
 }
 
 .c4 {
-  width: auto;
-  height: auto;
-  max-width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
 }
 
 .c4 > img {
-  width: auto;
-  height: auto;
-  max-width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  object-fit: contain;
 }
 
 @media (max-width:992px) {

--- a/src/@next/components/molecules/ProductTile/__snapshots__/stories.storyshot
+++ b/src/@next/components/molecules/ProductTile/__snapshots__/stories.storyshot
@@ -21,7 +21,6 @@ exports[`Storyshots @components/molecules/ProductTile default 1`] = `
   background: #f1f5f5;
   padding: 2.5rem;
   text-align: center;
-  max-height: 30rem;
   height: 26rem;
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/@next/components/molecules/ProductTile/styles.ts
+++ b/src/@next/components/molecules/ProductTile/styles.ts
@@ -12,6 +12,9 @@ export const Wrapper = styled.div`
   padding: 2.5rem;
   text-align: center;
   max-height: 30rem;
+  height: 26rem;
+  display: flex;
+  flex-direction: column;
   transition: 0.3s;
 
   :hover {
@@ -34,13 +37,12 @@ export const Price = styled.p`
 `;
 
 export const Image = styled.div`
-  width: auto;
-  height: auto;
-  max-width: 100%;
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
 
   > img {
-    width: auto;
-    height: auto;
-    max-width: 100%;
+    flex-grow: 1;
+    object-fit: contain;
   }
 `;

--- a/src/@next/components/molecules/ProductTile/styles.ts
+++ b/src/@next/components/molecules/ProductTile/styles.ts
@@ -11,7 +11,6 @@ export const Wrapper = styled.div`
   background: ${props => props.theme.colors.light};
   padding: 2.5rem;
   text-align: center;
-  max-height: 30rem;
   height: 26rem;
   display: flex;
   flex-direction: column;

--- a/src/@next/components/organisms/ProductGallery/__snapshots__/stories.storyshot
+++ b/src/@next/components/organisms/ProductGallery/__snapshots__/stories.storyshot
@@ -83,7 +83,7 @@ exports[`Storyshots @components/organisms/ProductGallery default 1`] = `
 }
 
 .c5 img {
-  max-height: 100%;
+  height: 100%;
   width: 100%;
   object-fit: contain;
 }
@@ -294,7 +294,7 @@ exports[`Storyshots @components/organisms/ProductGallery eight Images 1`] = `
 }
 
 .c8 img {
-  max-height: 100%;
+  height: 100%;
   width: 100%;
   object-fit: contain;
 }
@@ -607,7 +607,7 @@ exports[`Storyshots @components/organisms/ProductGallery three Images 1`] = `
 }
 
 .c6 img {
-  max-height: 100%;
+  height: 100%;
   width: 100%;
   object-fit: contain;
 }

--- a/src/@next/components/organisms/ProductGallery/__snapshots__/stories.storyshot
+++ b/src/@next/components/organisms/ProductGallery/__snapshots__/stories.storyshot
@@ -83,6 +83,7 @@ exports[`Storyshots @components/organisms/ProductGallery default 1`] = `
 }
 
 .c5 img {
+  max-height: 100%;
   width: 100%;
   object-fit: contain;
 }
@@ -293,6 +294,7 @@ exports[`Storyshots @components/organisms/ProductGallery eight Images 1`] = `
 }
 
 .c8 img {
+  max-height: 100%;
   width: 100%;
   object-fit: contain;
 }
@@ -605,6 +607,7 @@ exports[`Storyshots @components/organisms/ProductGallery three Images 1`] = `
 }
 
 .c6 img {
+  max-height: 100%;
   width: 100%;
   object-fit: contain;
 }

--- a/src/@next/components/organisms/ProductGallery/styles.ts
+++ b/src/@next/components/organisms/ProductGallery/styles.ts
@@ -79,7 +79,7 @@ export const Preview = styled.div`
   max-height: 560px;
   overflow: hidden;
   img {
-    max-height: 100%;
+    height: 100%;
     width: 100%;
     object-fit: contain;
   }

--- a/src/@next/components/organisms/ProductGallery/styles.ts
+++ b/src/@next/components/organisms/ProductGallery/styles.ts
@@ -79,6 +79,7 @@ export const Preview = styled.div`
   max-height: 560px;
   overflow: hidden;
   img {
+    max-height: 100%;
     width: 100%;
     object-fit: contain;
   }

--- a/src/@next/components/organisms/ProductList/__snapshots__/stories.storyshot
+++ b/src/@next/components/organisms/ProductList/__snapshots__/stories.storyshot
@@ -63,7 +63,6 @@ exports[`Storyshots @components/organisms/ProductList default 1`] = `
   background: #f1f5f5;
   padding: 2.5rem;
   text-align: center;
-  max-height: 30rem;
   height: 26rem;
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/@next/components/organisms/ProductList/__snapshots__/stories.storyshot
+++ b/src/@next/components/organisms/ProductList/__snapshots__/stories.storyshot
@@ -64,6 +64,14 @@ exports[`Storyshots @components/organisms/ProductList default 1`] = `
   padding: 2.5rem;
   text-align: center;
   max-height: 30rem;
+  height: 26rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   -webkit-transition: 0.3s;
   transition: 0.3s;
 }
@@ -87,15 +95,23 @@ exports[`Storyshots @components/organisms/ProductList default 1`] = `
 }
 
 .c5 {
-  width: auto;
-  height: auto;
-  max-width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
 }
 
 .c5 > img {
-  width: auto;
-  height: auto;
-  max-width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  object-fit: contain;
 }
 
 .c1 {


### PR DESCRIPTION
I want to merge this change because it:

- fixes product gallery preview height
- fixes thumbnail preview height on Order history
- fixes thumbnail height on listing of products

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/29279389/100752217-9b8bed00-33e8-11eb-8d88-8397f5d0a4db.png">

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/29279389/100752301-b9f1e880-33e8-11eb-89c3-11b1d62e0b42.png">

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/29279389/100752328-c5451400-33e8-11eb-8b8d-49477dab05f7.png">




<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
