### PR TITLE
Handle same value breadcrumbs in React keys

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -59,7 +59,7 @@ const Breadcrumbs: React.FC<{
           </li>
           {breadcrumbs.map((breadcrumb, index) => (
             <li
-              key={breadcrumb.value}
+              key={`${breadcrumb.value}-${index}`}
               className={classNames({
                 breadcrumbs__active: index === breadcrumbs.length - 1,
               })}


### PR DESCRIPTION
I want to merge this change because it fixes React warnings for multiple breadcrumbs with same value.

<!-- Please mention all relevant issue numbers. -->
closes #977 
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
