### PR TITLE
Fix dockerfiles for 3.0+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-ARG API_URI
+ARG NEXT_PUBLIC_API_URI
 ARG SENTRY_DSN
 ARG SENTRY_APM
 ARG DEMO_MODE
 ARG GTM_ID
-ENV API_URI ${API_URI:-http://localhost:8000/graphql/}
-RUN API_URI=${API_URI} npm run build:export
+ENV NEXT_PUBLIC_API_URI ${NEXT_PUBLIC_API_URI:-http://localhost:8000/graphql/}
+RUN NEXT_PUBLIC_API_URI=${NEXT_PUBLIC_API_URI} npm run build:export
 
 FROM nginx:stable
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,8 +3,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-ARG API_URI
-ENV API_URI ${API_URI:-http://localhost:8000/graphql/}
+ARG NEXT_PUBLIC_API_URI
+ENV NEXT_PUBLIC_API_URI ${NEXT_PUBLIC_API_URI:-http://localhost:8000/graphql/}
 
 EXPOSE 3000
-CMD npm start -- --hostname 0.0.0.0
+CMD npm start


### PR DESCRIPTION
I want to merge this change because dockerfiles were not updated for a while and they should use the `NEXT_PUBLIC_API_URI` env var.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/
